### PR TITLE
Docs: AWS permissions reference + Phase 5 workflow layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ supported as an alternative.
 ├── frontend/                 # React portal: Workbench, Publish, Debug, Scheduler, MCP & Skills, Channels, Memory, Observability, Eval, Governance
 ├── infrastructure/           # CDK (Python): VPC/NAT network, platform resources, AgentCore runtimes, portal hosting + scheduler engine
 ├── scripts/                  # Image build & deployment helpers
-└── docs/                     # Architecture, deployment and user guides
+└── docs/                     # Architecture, deployment, permissions, user guide
 ```
 
 **Ecosystem (Phase 2)**: the portal keeps a registry of **MCP servers** (hosted
@@ -152,6 +152,12 @@ on every API call). The web terminal grants a shell **inside the runtime
 container**; isolation relies on AgentCore microVM session isolation plus the
 VPC egress security group. Review [docs/architecture.md — Security notes](docs/architecture.md#security-notes)
 before exposing the portal beyond a demo audience.
+
+Deploying into a permission-controlled account? [**docs/permissions.md**](docs/permissions.md)
+is the code-verified IAM reference — every role's exact actions and resource
+scopes, the wildcard statements and why each is unavoidable, deployer
+permissions, and how to tighten for a locked-down environment. Written for a
+security team approving the deployment.
 
 ### Static-analysis suppressions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,6 +304,35 @@ free.
   an append-only audit log of every mutating platform action. Model
   allow-lists and budgets stay in the LLM gateway.
 
+### Workflow engine — pipeline-as-data (Phase 5, experimental)
+
+Multi-step agent orchestration expressed as a **Workflow-dialect script**
+(the same `agent()`/`parallel()`/`pipeline()`/`phase()`/`log()` primitives as
+the Claude Code Workflow tool) and registered as a named platform *pipeline*.
+
+- **Execution model** (`workflow_engine.py` + `backend/app/workflow/runner.mjs`)
+  — the script runs in a short-lived **Node subprocess**; every host primitive
+  is bridged back to the Python engine over a stdio NDJSON channel. The Node
+  shim makes **no AWS calls of its own** — `agent()` routes back into the same
+  governed invocation pipeline (quota → invoke → ledger), and
+  `s3read/s3write/s3list` are confined to the workspace bucket by the backend.
+  This keeps a workflow's trust model equivalent to a CI pipeline definition:
+  it is code, but its only I/O is the metered bridge.
+- **Feed layer** — remote MCP targets (e.g. Exa) carry a `{{secret:...}}`
+  placeholder that the **SDK kernel** resolves from Secrets Manager at session
+  start, so the API key is never stored in the registry in plaintext. Feed
+  agents that exceed the 15-minute synchronous invoke ceiling run as
+  **AgentCore async tasks** (up to the 8-hour async ceiling), writing their
+  answer + a status sidecar to dated S3 artifacts.
+- **Scheduling** — a schedule whose target is `pipeline:{name}` is fired by the
+  EventBridge Scheduler Lambda. Because workflow scripts need Node (only the
+  backend container has it), the Lambda **delegates** pipeline runs to the
+  backend API, authenticating as the portal admin via the
+  `agent-platform/portal-admin` secret.
+- **Tracing** — each run emits a root → phase → agent span trace to X-Ray
+  (`PutTraceSegments`); with Transaction Search enabled it renders in the
+  CloudWatch Traces console. The Workflow portal page shows the same tree live.
+
 ### 5. Frontend portal (`frontend/`)
 
 React + Vite + Tailwind. Information architecture:
@@ -321,6 +350,7 @@ React + Vite + Tailwind. Information architecture:
 | Memory | ✅ live | AgentCore Memory stores, event browser, semantic record search |
 | Evaluation | ✅ live | datasets, LLM-judged runs with per-case verdicts |
 | Governance | ✅ live | usage policy editor, today's usage, audit log |
+| Workflow | 🧪 experimental | register Workflow-dialect pipeline scripts; phase→agent run tree (Phase 5) |
 
 ### 6. Infrastructure (`infrastructure/`, CDK Python)
 
@@ -342,10 +372,21 @@ a new runtime version automatically).
   isolation comes from AgentCore microVMs plus the VPC egress security group.
 - Pre-signed WSS URLs expire in 5 minutes and are minted per connect request by
   the backend; the container's IAM role cannot mint URLs.
-- Runtime IAM role follows least privilege: S3 workspace prefix, specific
-  secrets, ECR pull, CloudWatch Logs.
+- Runtime IAM role follows least privilege: S3 workspace bucket, three
+  specifically-named secrets, ECR pull, CloudWatch Logs, AgentCore
+  memory/built-in-tool data-plane actions. No `bedrock:*` at all in the default
+  LLM-gateway mode.
 - No secrets are baked into images; keys are read from Secrets Manager at
-  container start.
+  container/Lambda start.
+- The browser and end users hold **no AWS credentials** — all AWS access is
+  server-side under four IAM roles.
 - If your LLM gateway is HTTP-only, traffic from NAT → gateway crosses the
   network unencrypted; put a TLS listener or PrivateLink in front for
   production.
+
+For the full, code-verified account of every IAM principal — exact actions,
+resource scopes, conditions, the handful of wildcard-resource statements
+(and why each is unavoidable), what is deliberately *not* granted, deployer
+permissions, and how to tighten for a locked-down environment — see
+[**permissions.md**](permissions.md). That document is written specifically for
+a security team approving a controlled deployment.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,6 +9,13 @@
 - Amazon Bedrock AgentCore available in your target region
 - Python ≥ 3.11, Node.js ≥ 20
 
+> **Deploying into a permission-controlled account?** Read
+> [permissions.md](permissions.md) first. It enumerates the four IAM roles the
+> platform creates (exact actions, resource scopes, conditions), the deployer
+> permissions `cdk deploy` itself needs, and how to hand the security team a
+> single reviewable artifact (`cdk synth --all`) instead of granting
+> speculative access. §8 and §10 there are written for exactly this case.
+
 ## 1. Network + platform resources
 
 ```bash
@@ -197,6 +204,45 @@ Auth modes (backend resolves in this order):
    manual walkthroughs of each page, see the
    [user guide](user-guide.md).
 
+## 7. (Optional) Content pipelines — Phase 5
+
+The workflow engine and the sample daily-topic / topic-selection pipelines are
+optional. Enable them only if you want scheduled, multi-step agent
+orchestration.
+
+1. **Store the Exa (or other remote-MCP) key** — the feed layer resolves a
+   `{{secret:agent-platform/exa-api-key}}` placeholder at session start; the key
+   is never stored in the registry:
+
+   ```bash
+   aws secretsmanager put-secret-value \
+     --secret-id agent-platform/exa-api-key \
+     --secret-string '{"api_key":"exa-your-key"}'
+   ```
+
+   The runtime role's `McpSecrets` statement is scoped to
+   `agent-platform/exa-api-key*` only — see [permissions.md §2](permissions.md#2-runtime-execution-role).
+
+2. **Register the sample pipelines** (writes pipeline definitions to DynamoDB
+   and the MCP/skill registry — no new infra):
+
+   ```bash
+   PLATFORM_WORKSPACE_BUCKET=agent-platform-workspaces-<account>-<region> \
+     python3 scripts/seed_topic_pipeline.py
+   ```
+
+3. **Stage the pipeline inputs** into the workspace bucket:
+
+   ```bash
+   PLATFORM_WORKSPACE_BUCKET=agent-platform-workspaces-<account>-<region> \
+     ./scripts/stage_topic_inputs.sh
+   ```
+
+These operator scripts run with **your CLI identity**, not a stack role —
+they need `s3:PutObject` on the workspace bucket and `dynamodb:PutItem` on the
+`agent-platform` table. The Workflow page (marked Experimental) then shows the
+registered pipelines and their phase→agent run tree.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
@@ -209,6 +255,8 @@ Auth modes (backend resolves in this order):
 | Built-in tool call fails with AccessDenied | Runtime execution role missing `StartCodeInterpreterSession` / `StartBrowserSession` (+ connect/invoke actions) on the account's `code-interpreter/*` / `browser/*` resources — see `RuntimeStack` `BuiltinTools` policy |
 | Schedules never fire (hosted) | Check the schedule-runner Lambda's logs (`/aws/lambda/agent-platform-schedule-runner`) and the `agent-platform-schedule-dlq` queue; a `RuntimeError: code not deployed` means `scripts/deploy-schedule-lambda.sh` hasn't been run. Verify the mirror exists: `aws scheduler get-schedule --group-name agent-platform --name sched-<id>` |
 | Schedules never fire (local dev) | The fallback tick loop runs inside the backend process — `uvicorn` must be running; check `enabled` and `next_run_at` on the Scheduler page |
+| Pipeline feed agent fails on the Exa MCP | `agent-platform/exa-api-key` secret not set, or the runtime role lacks `secretsmanager:GetSecretValue` on it (`McpSecrets` statement in `RuntimeStack`) |
+| `pipeline:{name}` schedule fails only when fired by the Lambda (works from the portal) | The Lambda delegates pipeline runs to the backend API as the portal admin — check the `agent-platform/portal-admin` secret exists and the Lambda role's `PortalAdminSecret` grant, and that `PLATFORM_PORTAL_API_URL` points at the CloudFront domain (not the bare ALB) |
 | Eval run stuck in `running` | Check backend logs; note that DynamoDB `UpdateExpression` treats `status`/`error` as reserved words — any new update expression must alias attribute names |
 | Memory store stays `CREATING` | Normal for the first few minutes after creation; AgentCore provisions the store asynchronously |
 | Memory retrieval returns nothing right after a conversation | Long-term extraction is asynchronous (typically under a minute); raw events are visible immediately on the Memory page |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,335 @@
+# AWS Permissions Reference
+
+This document is the authoritative, code-verified account of **every IAM
+principal the platform creates**, the exact actions and resource scopes each
+one holds, and *why*. It is written for a security team that has to approve the
+deployment into a controlled test environment.
+
+Everything here is derived from the CDK stacks in `infrastructure/stacks/` and
+cross-checked against the AWS API calls the code actually makes
+(`backend/`, `runtimes/`). Where a statement uses a wildcard resource
+(`"*"`), it is called out explicitly in
+[§4 Wildcard resources](#4-wildcard-resource-statements) with the reason and how
+to narrow it.
+
+`{region}` and `{account}` below are your deployment region and account ID; the
+stacks template these automatically.
+
+## Contents
+
+1. [Principals at a glance](#1-principals-at-a-glance)
+2. [Runtime execution role](#2-runtime-execution-role)
+3. [Backend (ECS task) role](#3-backend-ecs-task-role)
+4. [Wildcard resource statements](#4-wildcard-resource-statements)
+5. [Scheduler engine roles](#5-scheduler-engine-roles-lambda--eventbridge)
+6. [What is deliberately *not* granted](#6-what-is-deliberately-not-granted)
+7. [Authentication vs authorization](#7-authentication-vs-authorization)
+8. [Deployer / CDK permissions](#8-deployer--cdk-permissions)
+9. [Data and network boundaries](#9-data-and-network-boundaries)
+10. [Tightening for a locked-down environment](#10-tightening-for-a-locked-down-environment)
+
+---
+
+## 1. Principals at a glance
+
+The platform runs under four IAM principals. Three are execution roles for
+compute; one is a service role EventBridge Scheduler assumes.
+
+| # | Principal | Created in | Assumed by | Purpose |
+|---|---|---|---|---|
+| 1 | **`agent-platform-runtime-role`** | `RuntimeStack` | `bedrock-agentcore.amazonaws.com` | The IAM identity *inside* every kernel container (interactive, headless, MCP). Everything an agent does at runtime uses this role. |
+| 2 | **Backend task role** (`PortalStack/TaskRole`) | `PortalStack` | `ecs-tasks.amazonaws.com` | The control-plane API on ECS Fargate: session routing, invoking runtimes, memory/scheduler/eval management. |
+| 3 | **Schedule-runner Lambda role** (`PortalStack/ScheduleRunner`) | `PortalStack` | `lambda.amazonaws.com` | Fires scheduled invocations at each occurrence. Packages the same service layer as the backend. |
+| 4 | **Scheduler role** (`PortalStack/SchedulerRole`) | `PortalStack` | `scheduler.amazonaws.com` (conditioned on `aws:SourceAccount`) | The role EventBridge Scheduler assumes to invoke the runner Lambda and send to the DLQ. Holds no data-plane permissions. |
+
+The single most important property for a security review: **the browser and
+end users never hold AWS credentials.** All AWS access is server-side under
+these roles. The web terminal's WebSocket is reached through a SigV4 URL the
+backend pre-signs and hands to the browser with a 5-minute expiry; the
+container's own role cannot mint such URLs.
+
+---
+
+## 2. Runtime execution role
+
+`agent-platform-runtime-role` — shared by all three kernel runtimes
+(`claude_code_kernel`, `agent_sdk_kernel`, `mcp_tools_kernel`). This is the role
+a security team should scrutinize most, because it is the identity an agent's
+own code (and any tool it runs) executes under.
+
+**Trust policy:** assumed only by `bedrock-agentcore.amazonaws.com`.
+
+| Sid | Actions | Resource scope | Why |
+|---|---|---|---|
+| *(ECR pull, granted by `repo.grant_pull`)* | `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer`, `ecr:BatchCheckLayerAvailability` | The four `agent-platform/*` ECR repos only | Pull the kernel image at container start. |
+| `EcrAuth` | `ecr:GetAuthorizationToken` | `*` | Token endpoint is not resource-scopable (AWS API constraint). See [§4](#4-wildcard-resource-statements). |
+| `Logs` | `logs:CreateLogGroup`, `CreateLogStream`, `PutLogEvents`, `DescribeLogGroups`, `DescribeLogStreams` | `arn:aws:logs:{region}:{account}:log-group:/aws/bedrock-agentcore/*` | Kernel + AgentCore runtime logs. Scoped to the AgentCore log-group prefix. |
+| *(S3 workspace, `grant_read_write`)* | `s3:GetObject`, `PutObject`, `DeleteObject`, `GetBucket*`, `List*`, `Abort*` | `agent-platform-workspaces-{account}-{region}` bucket **and its objects only** | Per-session workspace + Claude Code state sync (`workspaces/{sessionId}/`), skill packages (`skills/`), and pipeline feed artifacts. |
+| *(LLM gateway secret, `grant_read`)* | `secretsmanager:GetSecretValue`, `DescribeSecret` | `agent-platform/llm-gateway-key-*` only | Read the gateway API key at container start (never baked into the image). |
+| `McpSecrets` | `secretsmanager:GetSecretValue` | `agent-platform/exa-api-key-*` only | **(Phase 5)** Resolve `{{secret:...}}` placeholders in remote-MCP registry targets (e.g. the Exa API key) at session start, so the key is never stored in the registry in plaintext. |
+| `InvokeMcpRuntimes` | `bedrock-agentcore:InvokeAgentRuntime` | `runtime/mcp_tools_kernel-*` and its `runtime-endpoint/*` only | Kernels reach the AgentCore-hosted MCP server through `mcp-proxy-for-aws`, which SigV4-signs with this role. Scoped to the MCP runtime name — **not** all runtimes. |
+| `BuiltinTools` | `bedrock-agentcore:StartCodeInterpreterSession`, `InvokeCodeInterpreter`, `StopCodeInterpreterSession`, `GetCodeInterpreterSession`, `StartBrowserSession`, `StopBrowserSession`, `GetBrowserSession`, `UpdateBrowserStream`, `ConnectBrowserAutomationStream`, `ConnectBrowserLiveViewStream` | `code-interpreter/aws.codeinterpreter.v1`, `browser/aws.browser.v1` (AWS-managed), plus `{account}:code-interpreter/*` and `{account}:browser/*` (custom variants) | Code Interpreter and Browser built-in tools run in AWS-managed sandboxes under this role — no separate tool runtime to deploy. |
+| `MemoryData` | `bedrock-agentcore:CreateEvent`, `GetEvent`, `ListEvents`, `ListActors`, `ListSessions`, `GetMemoryRecord`, `ListMemoryRecords`, `RetrieveMemoryRecords` | `memory/*` in this account/region | **Data plane only.** A memory-bound kernel retrieves long-term records before a run and appends the exchange as an event after. It **cannot** create, update, or delete memory stores — that is the backend's job (control plane). |
+| `BedrockInvoke` *(only when `use_bedrock=1`)* | `bedrock:InvokeModel`, `InvokeModelWithResponseStream` | `*` | Direct-Bedrock mode only. Cross-region inference profiles span regions, so this cannot be region-pinned. **Not present** in the default LLM-gateway mode. See [§4](#4-wildcard-resource-statements). |
+
+Notes for reviewers:
+
+- In the **default (LLM-gateway) mode**, the runtime role has **no `bedrock:*`
+  permission at all** — models are reached over HTTPS through your gateway, not
+  the Bedrock API. The `BedrockInvoke` statement is added *only* if you deploy
+  with `-c use_bedrock=1`.
+- The workspace S3 grant is bucket-scoped, but a session's role can read *any*
+  session's prefix within that bucket (there is no per-session prefix
+  condition). If cross-session isolation of workspace files is a requirement,
+  see [§10](#10-tightening-for-a-locked-down-environment).
+
+---
+
+## 3. Backend (ECS task) role
+
+`PortalStack/TaskRole` — the control-plane API. **Trust policy:** assumed only
+by `ecs-tasks.amazonaws.com`.
+
+| Sid | Actions | Resource scope | Why |
+|---|---|---|---|
+| *(DynamoDB, `grant_read_write_data`)* | `dynamodb:GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `Query`, `Scan`, `BatchGet*`, `BatchWrite*`, `ConditionCheckItem`, `DescribeTable` | The `agent-platform` table (+ its indexes) only | Single-table store: sessions, published agents, ecosystem registry, schedules, channels, eval runs, invocation ledger, governance policy, audit log. |
+| *(S3 workspace, `grant_read_write`)* | as runtime role above | `agent-platform-workspaces-*` bucket + objects only | Browse session artifacts (read) and write skill packages / self-service publish manifests / pipeline outputs. |
+| `AgentCoreInvoke` | `bedrock-agentcore:InvokeAgentRuntime`, `InvokeAgentRuntimeWithWebSocketStream`, `GetAgentRuntime`, `GetAgentRuntimeEndpoint` | `runtime/*` in this account/region | Warmup + invoke kernels; the WebSocket action is required to pre-sign the terminal `/ws` URL. Scoped to runtimes in this account/region. |
+| `AgentCoreMemory` | `bedrock-agentcore:CreateMemory`, `GetMemory`, `UpdateMemory`, `DeleteMemory`, `GetEvent`, `ListEvents`, `ListActors`, `ListSessions`, `GetMemoryRecord`, `ListMemoryRecords`, `RetrieveMemoryRecords` | `memory/*` in this account/region | Memory page: full control plane (create/update/delete stores) + data-plane browsing. |
+| `AgentCoreMemoryList` | `bedrock-agentcore:ListMemories` | `*` | `ListMemories` is not resource-scopable (AWS API constraint). See [§4](#4-wildcard-resource-statements). |
+| `PipelineTraces` | `xray:PutTraceSegments`, `PutTelemetryRecords` | `*` | **(Phase 5)** Emit the pipeline orchestration trace (root → phase → agent spans). X-Ray segment ingestion is not resource-scopable. See [§4](#4-wildcard-resource-statements). |
+| `SchedulerCrud` | `scheduler:CreateSchedule`, `UpdateSchedule`, `DeleteSchedule`, `GetSchedule`, `ListSchedules` | `schedule/agent-platform/*` only | Mirror platform schedules into the dedicated `agent-platform` schedule group. Scoped to that group — cannot touch other schedules in the account. |
+| `PassSchedulerRole` | `iam:PassRole` | The `SchedulerRole` ARN only | Pass the scheduler role to EventBridge when creating a schedule. Constrained by `iam:PassedToService = scheduler.amazonaws.com` — the role can only be passed to EventBridge Scheduler, nothing else. |
+
+Notes for reviewers:
+
+- **No `cognito-idp` IAM permission.** The backend verifies Cognito ID tokens
+  by fetching the pool's public JWKS over HTTPS (`app/auth.py`) — a pure
+  signature check, no AWS API call. See [§7](#7-authentication-vs-authorization).
+- **No `secretsmanager` permission on the task role.** The one code path that
+  reads the `portal-admin` secret (pipeline-schedule delegation) runs in the
+  **Lambda**, which has its own scoped grant — not in the backend task.
+
+---
+
+## 4. Wildcard resource statements
+
+A strict security review will flag every `"Resource": "*"`. There are exactly
+**four** in this platform, and each is a wildcard because the underlying AWS API
+does not support resource-level scoping — not because of loose policy authoring.
+
+| Statement | Principal(s) | Why `*` is required | Blast radius |
+|---|---|---|---|
+| `ecr:GetAuthorizationToken` | Runtime role | The ECR auth-token endpoint is account-global; AWS rejects a resource ARN on this action. | Returns a 12-hour registry token. Pulling an actual image still requires the repo-scoped `ecr:BatchGetImage` grant, which **is** restricted to `agent-platform/*`. |
+| `bedrock-agentcore:ListMemories` | Backend task role | `List*` on AgentCore Memory is not resource-scopable. | Lists memory store metadata in the account/region. All *mutating* and *record-reading* memory actions are scoped to `memory/*`. |
+| `xray:PutTraceSegments`, `PutTelemetryRecords` | Backend task role, Lambda role | X-Ray segment ingestion has no resource dimension. | Write-only trace ingestion. Cannot read traces, cannot touch any other service. |
+| `bedrock:InvokeModel*` | Runtime role, **only if `use_bedrock=1`** | Cross-region inference profiles span multiple regions, so a single-region ARN would break invocation. | Model invocation only. Absent entirely in the default LLM-gateway mode. If you need to constrain models in Bedrock mode, do it with a permission boundary or SCP on inference-profile ARNs, or keep model governance in the LLM gateway. |
+
+Everything else in the platform is scoped to a specific bucket, table, secret
+name prefix, schedule group, runtime-name prefix, or account/region resource
+partition.
+
+---
+
+## 5. Scheduler engine roles (Lambda + EventBridge)
+
+Present only when you deploy `PortalStack` (the scheduler firing engine). Local
+development uses an in-process tick loop with no extra roles.
+
+### Schedule-runner Lambda role (`PortalStack/ScheduleRunner`)
+
+Fires each scheduled occurrence through the same governed invocation pipeline.
+Trust: `lambda.amazonaws.com`.
+
+| Sid | Actions | Resource scope | Why |
+|---|---|---|---|
+| *(DynamoDB `grant_read_write_data`)* | as backend | `agent-platform` table | Read the schedule, record the invocation. |
+| *(S3 `grant_read_write`)* | as backend | `agent-platform-workspaces-*` | **(Phase 5)** Pipeline schedules read staged feeds and write the shortlist. |
+| `AgentCoreInvoke` | `bedrock-agentcore:InvokeAgentRuntime` | `runtime/*` in this account/region | Invoke the target kernel/agent. |
+| `PipelineTraces` | `xray:PutTraceSegments`, `PutTelemetryRecords` | `*` | Trace the fired run (see [§4](#4-wildcard-resource-statements)). |
+| `PortalAdminSecret` | `secretsmanager:GetSecretValue` | `agent-platform/portal-admin-*` only | **(Phase 5)** Pipeline (workflow-script) schedules need Node, which only the backend container has. The Lambda delegates those to the backend API, authenticating as the portal admin. Non-pipeline schedules do not use this. |
+
+The Lambda also holds the CloudWatch Logs grant for its own log group
+(`/aws/lambda/agent-platform-schedule-runner`), added implicitly by the CDK
+`Function` construct.
+
+### Scheduler role (`PortalStack/SchedulerRole`)
+
+The role EventBridge Scheduler assumes at each occurrence. **No data-plane
+permissions.** Trust is conditioned so only EventBridge in *this account* can
+assume it:
+
+```json
+"Condition": { "StringEquals": { "aws:SourceAccount": "{account}" } }
+```
+
+| Granted via | Actions | Resource |
+|---|---|---|
+| `runner_fn.grant_invoke` | `lambda:InvokeFunction` | The schedule-runner Lambda only |
+| `schedule_dlq.grant_send_messages` | `sqs:SendMessage`, `GetQueueAttributes`, `GetQueueUrl` | The `agent-platform-schedule-dlq` queue only |
+
+---
+
+## 6. What is deliberately *not* granted
+
+Negative space matters as much as the grants. None of the platform roles can:
+
+- **Create, delete, or modify IAM** (roles, policies, users). `iam:PassRole` on
+  the task role is scoped to a single role ARN and conditioned to EventBridge
+  Scheduler only.
+- **Read secrets outside the three named `agent-platform/*` secrets**
+  (`llm-gateway-key`, `exa-api-key`, `portal-admin`). No `secretsmanager:*`
+  wildcard exists anywhere.
+- **Touch other accounts.** Every resource ARN is `{account}`-scoped; there is
+  no cross-account trust and no `sts:AssumeRole` into other accounts.
+- **Read X-Ray traces, CloudWatch metrics, or other teams' logs.** Log grants
+  are prefix-scoped (`/aws/bedrock-agentcore/*`, the backend's own group); X-Ray
+  is write-only.
+- **Manage networking** (VPC, security groups, route tables, EIPs) at runtime.
+  Those are created once by the CDK deployer, not by any running role.
+- **Invoke arbitrary runtimes from inside a kernel.** The runtime role's only
+  `InvokeAgentRuntime` grant is scoped to the MCP tools runtime name — a kernel
+  cannot invoke the backend's targets or other kernels.
+- **Reach the internet outside the VPC egress path.** All runtime egress leaves
+  through the single NAT Gateway EIP; there is no public IP on the runtime ENIs.
+
+---
+
+## 7. Authentication vs authorization
+
+Two separate concerns, easy to conflate in a review:
+
+- **Who can call the portal API** (authentication) is enforced by the **Cognito
+  user pool**, not IAM. Every `/api` request must carry a valid Cognito **ID
+  token**; the backend verifies its signature against the pool JWKS, issuer,
+  audience, and `token_use` claim (`app/auth.py`). This needs **no IAM
+  permission** — it is an HTTPS fetch of public keys. Self-signup is disabled;
+  an operator creates users with `admin-create-user`.
+- **What the backend may do in AWS** (authorization) is the task role in
+  [§3](#3-backend-ecs-task-role).
+- **Channels** are the one path that bypasses Cognito by design: a webhook is
+  authenticated by a server-generated bearer token (shown once, constant-time
+  compared), so external systems need no AWS credentials and no pool user. The
+  token grants only the ability to invoke that one channel's bound agent
+  through the governed pipeline.
+
+Fallback auth modes (backend resolves in order): Cognito → static bearer token
+(`PLATFORM_API_TOKEN`, for CI) → open (local dev only). For a controlled test
+environment, keep Cognito on; never ship the open mode.
+
+---
+
+## 8. Deployer / CDK permissions
+
+The roles above are what the platform runs *as*. Separately, whoever runs
+`cdk deploy` needs permission to **create** them. In a locked-down account the
+deploy identity is usually the tightest gate.
+
+Practical options, tightest first:
+
+1. **CDK execution role via `cdk bootstrap` (recommended).** Bootstrap the
+   account with a permissions boundary or a scoped
+   `--cloudformation-execution-policies`, and let CloudFormation assume the
+   bootstrap deploy role. The human then only needs `sts:AssumeRole` into the
+   CDK roles, not broad admin. This is the standard pattern for accounts where
+   engineers cannot hold `AdministratorAccess`.
+2. **A scoped deploy policy** covering the services the stacks create:
+   `cloudformation:*` (on `AgentPlatform*` stacks), `ec2:*` (VPC, subnets, NAT,
+   EIP, security groups — NetworkStack), `s3:*` (create the two buckets),
+   `dynamodb:*` (the table), `ecr:*` (the four repos), `secretsmanager:*` (the
+   three secrets), `iam:CreateRole/PutRolePolicy/PassRole/...` (the four roles),
+   `bedrock-agentcore:*Runtime*` (RuntimeStack), `ecs:*`, `elasticloadbalancing:*`,
+   `cloudfront:*`, `cognito-idp:*`, `lambda:*`, `scheduler:*`, `sqs:*`, and
+   `logs:*` (PortalStack). Constrain with a permissions boundary.
+
+Two hard requirements regardless of option:
+
+- **`iam:PassRole`** — CDK must pass the execution/task/Lambda roles to
+  Bedrock AgentCore, ECS, and Lambda respectively. Scope `PassRole` to the four
+  `agent-platform*` role ARNs if you write a custom deploy policy.
+- **The image-push and code-deploy scripts run with your CLI identity, not a
+  stack role.** `scripts/build-and-push.sh` needs `ecr:GetAuthorizationToken` +
+  push actions on `agent-platform/*`; `scripts/deploy-schedule-lambda.sh` needs
+  `lambda:UpdateFunctionCode` on the runner; the Phase 5
+  `scripts/seed_topic_pipeline.py` / `stage_topic_inputs.sh` need
+  `s3:PutObject` on the workspace bucket and `dynamodb:PutItem` on the table.
+  These are operator actions, deliberately kept out of the stack roles.
+
+If the customer wants a single reviewable artifact, generate the synthesized
+templates and hand those to the security team instead of granting speculative
+permissions:
+
+```bash
+cd infrastructure && cdk synth --all      # writes cdk.out/*.template.json
+```
+
+Every IAM statement in this document appears verbatim in those templates.
+
+---
+
+## 9. Data and network boundaries
+
+Where data lives and how it is protected, for the data-classification part of a
+review:
+
+| Store | Contents | Protection |
+|---|---|---|
+| Workspace S3 bucket | Session files, Claude Code conversation history, skill packages, pipeline feed artifacts | `BLOCK_ALL` public access, S3-managed encryption, `enforce_ssl=True`, `RETAIN` on stack delete (so session data is not lost accidentally). Access only via the two roles above. |
+| DynamoDB `agent-platform` | Session/agent/schedule/channel/eval/ledger/policy/audit records | Encrypted at rest (AWS-owned key by default; switch to a CMK if required). PAY_PER_REQUEST. |
+| Secrets Manager (`agent-platform/*`) | LLM gateway key, Exa API key, portal-admin password | Encrypted; read only by the specifically-scoped roles. Never baked into images — read at container/Lambda start. |
+| CloudWatch Logs | Kernel, backend, and Lambda logs | Prefix-scoped grants; one-week retention on the platform's own groups. |
+
+Network boundary:
+
+- Runtimes run in **VPC mode** on private subnets; all egress leaves through one
+  NAT Gateway with a **fixed EIP** — allow-list that single `/32` on your LLM
+  gateway. Runtime ENIs have no public IP.
+- The runtime security group is **egress-only** — AgentCore delivers inbound
+  traffic through its data plane, not the VPC, so no ingress rule exists.
+- The ALB accepts traffic **only from CloudFront** (ingress restricted to the
+  `com.amazonaws.global.cloudfront.origin-facing` managed prefix list); the ECS
+  service accepts traffic only from the ALB. CloudFront redirects all viewers to
+  HTTPS.
+- ⚠️ If your LLM gateway is HTTP-only, NAT → gateway traffic crosses the network
+  unencrypted. Put a TLS listener or PrivateLink in front for a real
+  environment.
+
+---
+
+## 10. Tightening for a locked-down environment
+
+Concrete changes for a customer whose security bar is stricter than a
+demo's. Each is a small, local edit — the platform is built to be forked
+(see [EXTENDING.md](../EXTENDING.md)).
+
+1. **Per-session workspace isolation.** Today any session's runtime role can
+   read any prefix in the workspace bucket. If sessions must not read each
+   other's files, split the runtime role per session or add an
+   `s3:prefix`/`aws:PrincipalTag` condition keyed to the session ID. (This
+   requires session-scoped roles or ABAC — a non-trivial change; scope it with
+   the customer.)
+2. **Customer-managed KMS keys.** Swap `BucketEncryption.S3_MANAGED` and the
+   DynamoDB default key for a CMK, and add `kms:Decrypt`/`GenerateDataKey`
+   (scoped to that key ARN) to the roles that touch the store. Gives you a key
+   policy as an independent second gate and full CloudTrail on key use.
+3. **Constrain models in Bedrock-direct mode.** The `bedrock:InvokeModel*`
+   wildcard ([§4](#4-wildcard-resource-statements)) can be bounded with an SCP
+   or permission boundary listing the allowed inference-profile ARNs. Or keep
+   `use_bedrock` off and enforce the model allow-list in the LLM gateway, where
+   it belongs.
+4. **Turn off the built-in tools you don't use.** If Code Interpreter / Browser
+   are out of scope, remove the `BuiltinTools` statement from `RuntimeStack` and
+   drop the corresponding registry seeds — the agents simply won't have those
+   tools.
+5. **Drop Bedrock entirely if you only use the gateway.** Confirm `use_bedrock`
+   is unset; the runtime role then carries **no** `bedrock:*` permission at all.
+6. **Shorten secret and log retention / add a CMK on the DLQ** per your
+   data-retention policy.
+7. **Require a permissions boundary on all four roles.** Attach a
+   customer-standard boundary in the CDK (`iam.Role(..., permissions_boundary=…)`)
+   so the roles can never be widened later beyond the boundary — a durable
+   guardrail independent of code review.
+
+For anything that changes a role's scope, re-run `cdk synth --all` and diff the
+resulting `AWS::IAM::Policy` resources so the security team reviews the exact
+JSON that will be deployed.


### PR DESCRIPTION
## What

- **New `docs/permissions.md`** — a code-verified IAM reference for deploying into a permission-controlled account. Enumerates the four IAM principals (runtime execution role, backend ECS task role, schedule-runner Lambda role, EventBridge Scheduler role) with exact actions, resource scopes, and conditions; explains the four unavoidable wildcard-resource statements (ECR auth token, `ListMemories`, X-Ray ingest, cross-region Bedrock profiles) with blast radius; documents what is deliberately *not* granted; covers deployer/CDK permissions; and gives a tightening playbook for locked-down environments.
- **`docs/architecture.md` / `docs/deployment.md`** — brought up to **Phase 5** (workflow engine / pipeline-as-data, remote-MCP `{{secret:}}` resolution, AgentCore async feed tasks, `pipeline:{name}` scheduling) and cross-linked to the new permissions doc.
- **`README.md`** — links the permissions reference from the Security section.

## Why

The published docs stopped at Phase 4 and there was no detailed AWS permission reference — only a short "Security notes" list. Adopters deploying into accounts with strict permission controls need the exact IAM surface and a review-ready artifact.

## Verification

- Every named IAM Sid in `permissions.md` maps 1:1 to a statement in `infrastructure/stacks/` (verified by diff).
- Grants cross-checked against an inventory of every boto3 call in `backend/` and `runtimes/`.
- All internal anchor links resolve.
- Docs-only change; no code or infrastructure modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)