### PR TITLE
Hero architecture diagram: add the AgentCore Gateway path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,8 +57,9 @@ The platform hosts two kinds of agent kernels behind one control plane:
 
 This sketch shows the two kernel paths; the full picture — including the
 EventBridge Scheduler → Lambda firing engine, channel webhooks, AgentCore
-Memory and the data stores — is the animated diagram in the README
-(`docs/images/architecture.svg`).
+Memory, the data stores, and the AgentCore Gateway that turns existing
+enterprise APIs into MCP tools carrying the caller's own identity — is the
+animated diagram in the README (`docs/images/architecture.svg`).
 
 ## Components
 

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,22 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1480 900" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-label="Agent Platform on Amazon Bedrock AgentCore">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1620 900" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-label="Agent Platform on Amazon Bedrock AgentCore">
 <title>Agent Platform on Amazon Bedrock AgentCore</title>
 <defs>
 <pattern id="grid" width="34" height="34" patternUnits="userSpaceOnUse"><path d="M34 0 H0 V34" fill="none" stroke="#EAEFF6" stroke-width="1"/></pattern>
 <marker id="ah" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M1 1 L9 5 L1 9" fill="none" stroke="context-stroke" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></marker>
 <style>@media (prefers-reduced-motion: no-preference){.flow{stroke-dasharray:6 6;animation:dm .8s linear infinite}}@keyframes dm{to{stroke-dashoffset:-12}}</style>
 </defs>
-<rect width="1480" height="900" fill="#FBFCFE"/><rect width="1480" height="900" fill="url(#grid)"/>
+<rect width="1620" height="900" fill="#FBFCFE"/><rect width="1620" height="900" fill="url(#grid)"/>
 <text x="40" y="46" font-size="21" font-weight="800" fill="#16202E">Agent Platform on Amazon Bedrock AgentCore</text>
-<text x="40" y="68" font-size="12" fill="#5A6B7B">Interactive cloud workspaces (Claude Code web terminal) + headless agent kernels behind one portal · schedules, channels, memory and evals through one governed pipeline · fixed-EIP egress to an IP-allow-listed LLM gateway</text>
-<rect x="200" y="88" width="1125" height="652" rx="12" fill="rgba(0,164,166,0.045)" stroke="#00A4A6" stroke-width="1.5" stroke-dasharray="9 5"/>
+<text x="40" y="68" font-size="12" fill="#5A6B7B">Interactive cloud workspaces (Claude Code web terminal) + headless agent kernels behind one portal · schedules, channels, memory and evals through one governed pipeline · fixed-EIP egress to an IP-allow-listed LLM gateway · existing APIs via AgentCore Gateway</text>
+<rect x="200" y="88" width="1265" height="652" rx="12" fill="rgba(0,164,166,0.045)" stroke="#00A4A6" stroke-width="1.5" stroke-dasharray="9 5"/>
 <text x="218" y="728" font-size="11" font-weight="700" fill="#0B7E7F">AWS Cloud</text>
-<rect x="740" y="134" width="565" height="374" rx="12" fill="rgba(140,79,255,0.06)" stroke="#8C4FFF" stroke-width="1.5" stroke-dasharray="6 4"/>
+<rect x="740" y="122" width="565" height="386" rx="12" fill="rgba(140,79,255,0.06)" stroke="#8C4FFF" stroke-width="1.5" stroke-dasharray="6 4"/>
 <text x="756" y="152" font-size="11" font-weight="700" fill="#7C3AED">VPC (private subnets)</text>
 <path class="flow" d="M 115.0 408.0 L 307.0 408.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
 <path class="flow" d="M 353.0 408.0 L 547.0 408.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
 <path class="flow" d="M 593.0 408.0 L 807.0 408.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
 <path class="flow" d="M 853.0 408.0 L 1057.0 408.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
-<path class="flow" d="M 1103.0 408.0 L 1367.0 408.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
+<path class="flow" d="M 1103.0 408.0 L 1517.0 408.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
 <path class="flow" d="M 115.0 560.0 L 180.0 560.0 L 180.0 408.0 L 307.0 408.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
 <path class="flow" d="M 92.0 385.0 L 92.0 104.0 L 830.0 104.0 L 830.0 385.0" fill="none" stroke="#0369A1" stroke-width="2" marker-end="url(#ah)"/>
 <path class="flow" d="M 570.0 385.0 L 570.0 262.0 L 930.0 262.0 L 930.0 168.0 L 977.0 168.0" fill="none" stroke="#1D4ED8" stroke-width="2" marker-end="url(#ah)"/>
@@ -31,6 +31,8 @@
 <path d="M 807.0 408.0 L 807.0 520.0 L 300.0 520.0 L 300.0 637.0" fill="none" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="2 5" opacity="0.7"/>
 <path d="M 1080.0 431.0 L 1080.0 568.0 L 1220.0 568.0 L 1220.0 637.0" fill="none" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="2 5" opacity="0.7"/>
 <path d="M 330.0 191.0 L 330.0 385.0" fill="none" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="2 5" opacity="0.7"/>
+<path class="flow" d="M 1000.0 191.0 L 1000.0 300.0 L 1367.0 300.0" fill="none" stroke="#0369A1" stroke-width="2" marker-end="url(#ah)"/>
+<path class="flow" d="M 1413.0 300.0 L 1517.0 300.0" fill="none" stroke="#0369A1" stroke-width="2" marker-end="url(#ah)"/>
 <rect x="192" y="385" width="41" height="14" rx="3" fill="#FBFCFE" opacity="0.92"/>
 <text x="212" y="395" text-anchor="middle" font-size="9.5" fill="#48586a">HTTPS</text>
 <rect x="406" y="385" width="87" height="14" rx="3" fill="#FBFCFE" opacity="0.92"/>
@@ -69,12 +71,16 @@
 <text x="1168" y="585" text-anchor="middle" font-size="9.5" fill="#48586a">alt: Bedrock direct</text>
 <rect x="270" y="290" width="120" height="14" rx="3" fill="#FBFCFE" opacity="0.92"/>
 <text x="330" y="300" text-anchor="middle" font-size="9.5" fill="#48586a">ID / access token</text>
+<rect x="1090" y="278" width="166" height="14" rx="3" fill="#FBFCFE" opacity="0.92"/>
+<text x="1173" y="288" text-anchor="middle" font-size="9.5" fill="#48586a">MCP · caller's own token</text>
+<rect x="1418" y="278" width="94" height="14" rx="3" fill="#FBFCFE" opacity="0.92"/>
+<text x="1465" y="288" text-anchor="middle" font-size="9.5" fill="#48586a">OBO / API key</text>
 <circle r="4" fill="#1D4ED8"><animateMotion dur="2.8s" begin="0.00s" repeatCount="indefinite" path="M 115.0 408.0 L 307.0 408.0"/></circle>
 <circle r="4" fill="#1D4ED8"><animateMotion dur="2.8s" begin="0.56s" repeatCount="indefinite" path="M 353.0 408.0 L 547.0 408.0"/></circle>
 <circle r="4" fill="#1D4ED8"><animateMotion dur="2.8s" begin="1.12s" repeatCount="indefinite" path="M 593.0 408.0 L 807.0 408.0"/></circle>
 <circle r="4" fill="#1D4ED8"><animateMotion dur="2.8s" begin="1.68s" repeatCount="indefinite" path="M 853.0 408.0 L 1057.0 408.0"/></circle>
-<circle r="4" fill="#1D4ED8"><animateMotion dur="2.8s" begin="2.24s" repeatCount="indefinite" path="M 1103.0 408.0 L 1367.0 408.0"/></circle>
-<circle r="3.4" fill="#0F766E"><animateMotion dur="3.2s" begin="0.00s" repeatCount="indefinite" keyPoints="1;0" keyTimes="0;1" calcMode="linear" path="M 1103.0 408.0 L 1367.0 408.0"/></circle>
+<circle r="4" fill="#1D4ED8"><animateMotion dur="2.8s" begin="2.24s" repeatCount="indefinite" path="M 1103.0 408.0 L 1517.0 408.0"/></circle>
+<circle r="3.4" fill="#0F766E"><animateMotion dur="3.2s" begin="0.00s" repeatCount="indefinite" keyPoints="1;0" keyTimes="0;1" calcMode="linear" path="M 1103.0 408.0 L 1517.0 408.0"/></circle>
 <circle r="3.4" fill="#0F766E"><animateMotion dur="3.2s" begin="0.64s" repeatCount="indefinite" keyPoints="1;0" keyTimes="0;1" calcMode="linear" path="M 853.0 408.0 L 1057.0 408.0"/></circle>
 <circle r="3.4" fill="#0F766E"><animateMotion dur="3.2s" begin="1.28s" repeatCount="indefinite" keyPoints="1;0" keyTimes="0;1" calcMode="linear" path="M 593.0 408.0 L 807.0 408.0"/></circle>
 <circle r="3.4" fill="#0F766E"><animateMotion dur="3.2s" begin="1.92s" repeatCount="indefinite" keyPoints="1;0" keyTimes="0;1" calcMode="linear" path="M 353.0 408.0 L 547.0 408.0"/></circle>
@@ -84,6 +90,8 @@
 <circle r="4" fill="#1D4ED8"><animateMotion dur="2.2s" begin="1.10s" repeatCount="indefinite" path="M 1023.0 168.0 L 1197.0 168.0"/></circle>
 <circle r="4" fill="#15803D"><animateMotion dur="2.6s" begin="0.00s" repeatCount="indefinite" path="M 513.0 168.0 L 657.0 168.0"/></circle>
 <circle r="4" fill="#15803D"><animateMotion dur="2.6s" begin="1.30s" repeatCount="indefinite" path="M 680.0 145.0 L 680.0 124.0 L 1000.0 124.0 L 1000.0 145.0"/></circle>
+<circle r="4" fill="#0369A1"><animateMotion dur="2.2s" begin="0.00s" repeatCount="indefinite" path="M 1000.0 191.0 L 1000.0 300.0 L 1367.0 300.0"/></circle>
+<circle r="4" fill="#0369A1"><animateMotion dur="2.2s" begin="1.10s" repeatCount="indefinite" path="M 1413.0 300.0 L 1517.0 300.0"/></circle>
 <rect x="69.0" y="385.0" width="46" height="46" rx="8" fill="#64748B"/><circle cx="92" cy="408" r="7" fill="none" stroke="#fff" stroke-width="2.4"/><circle cx="92" cy="408" r="1.8" fill="#fff"/><text x="92" y="446" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">Developer Browser</text><text x="92" y="459" text-anchor="middle" font-size="9.5" fill="#5A6B7B">portal · xterm.js</text>
 <rect x="69.0" y="537.0" width="46" height="46" rx="8" fill="#64748B"/><circle cx="92" cy="560" r="7" fill="none" stroke="#fff" stroke-width="2.4"/><circle cx="92" cy="560" r="1.8" fill="#fff"/><text x="92" y="598" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">External Systems</text><text x="92" y="611" text-anchor="middle" font-size="9.5" fill="#5A6B7B">bots · CI · ops hooks</text>
 <g transform="translate(307.00,385.00) scale(0.7188)">
@@ -132,7 +140,7 @@
         <path d="M13.6255,35.9209 L13.6255,33.0829 L15.3995,34.5019 L13.6255,35.9209 Z M13.2505,30.2209 C12.9495,29.9799 12.5365,29.9329 12.1915,30.1009 C11.8465,30.2679 11.6255,30.6169 11.6255,31.0019 L11.6255,38.0019 C11.6255,38.3869 11.8465,38.7359 12.1915,38.9029 C12.3305,38.9699 12.4785,39.0019 12.6255,39.0019 C12.8485,39.0019 13.0695,38.9279 13.2505,38.7829 L17.6255,35.2829 C17.8625,35.0929 18.0005,34.8059 18.0005,34.5019 C18.0005,34.1979 17.8625,33.9109 17.6255,33.7209 L13.2505,30.2209 Z M37.2515,26.8369 L37.2515,22.9149 L39.2125,24.8759 L37.2515,26.8369 Z M41.3335,24.1689 L36.9585,19.7939 C36.6725,19.5079 36.2445,19.4219 35.8685,19.5769 C35.4945,19.7319 35.2515,20.0969 35.2515,20.5009 L35.2515,23.8759 L27.6255,23.8759 L27.6255,14.3759 C27.6255,13.8229 27.1785,13.3759 26.6255,13.3759 L18.9315,13.3759 L18.9315,15.3759 L25.6255,15.3759 L25.6255,23.8759 L18.7505,23.8759 L18.7505,25.8759 L25.6255,25.8759 L25.6255,34.3769 L18.9315,34.3769 L18.9315,36.3769 L26.6255,36.3769 C27.1785,36.3769 27.6255,35.9299 27.6255,35.3769 L27.6255,25.8759 L35.2515,25.8759 L35.2515,29.2519 C35.2515,29.6559 35.4955,30.0219 35.8685,30.1759 C35.9925,30.2279 36.1225,30.2519 36.2515,30.2519 C36.5115,30.2519 36.7675,30.1499 36.9585,29.9589 L41.3335,25.5829 C41.7245,25.1919 41.7245,24.5599 41.3335,24.1689 L41.3335,24.1689 Z M13.6255,26.2959 L13.6255,23.4569 L15.3995,24.8759 L13.6255,26.2959 Z M13.2505,20.5949 C12.9495,20.3539 12.5365,20.3079 12.1915,20.4749 C11.8465,20.6419 11.6255,20.9909 11.6255,21.3759 L11.6255,28.3769 C11.6255,28.7619 11.8465,29.1109 12.1915,29.2779 C12.3305,29.3449 12.4785,29.3769 12.6255,29.3769 C12.8485,29.3769 13.0695,29.3029 13.2505,29.1579 L17.6255,25.6569 C17.8625,25.4669 18.0005,25.1799 18.0005,24.8759 C18.0005,24.5719 17.8625,24.2849 17.6255,24.0949 L13.2505,20.5949 Z M13.6255,15.7949 L13.6255,12.9569 L15.3995,14.3759 L13.6255,15.7949 Z M13.2505,10.0949 C12.9495,9.8539 12.5365,9.8069 12.1915,9.9749 C11.8465,10.1419 11.6255,10.4909 11.6255,10.8759 L11.6255,17.8759 C11.6255,18.2609 11.8465,18.6099 12.1915,18.7769 C12.3305,18.8439 12.4785,18.8759 12.6255,18.8759 C12.8485,18.8759 13.0695,18.8019 13.2505,18.6569 L17.6255,15.1569 C17.8625,14.9669 18.0005,14.6799 18.0005,14.3759 C18.0005,14.0719 17.8625,13.7849 17.6255,13.5949 L13.2505,10.0949 Z M24.0005,44.0029 C12.9725,44.0029 3.9995,35.0299 3.9995,24.0009 C3.9995,12.9729 12.9725,3.9999 24.0005,3.9999 C35.0295,3.9999 44.0025,12.9729 44.0025,24.0009 C44.0025,35.0299 35.0295,44.0029 24.0005,44.0029 L24.0005,44.0029 Z M24.0005,1.9999 C11.8685,1.9999 1.9995,11.8689 1.9995,24.0009 C1.9995,36.1329 11.8685,46.0029 24.0005,46.0029 C36.1325,46.0029 46.0025,36.1329 46.0025,24.0009 C46.0025,11.8689 36.1325,1.9999 24.0005,1.9999 L24.0005,1.9999 Z" id="nat__AWS-Amazon-VPC_NAT-gateway_Resource-Icon_light-bg" fill="#8C4FFF"></path>
     </g>
 </g><text x="1080" y="446" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">NAT Gateway</text><text x="1080" y="459" text-anchor="middle" font-size="9.5" fill="#5A6B7B">fixed EIP</text>
-<rect x="1367.0" y="385.0" width="46" height="46" rx="8" fill="#4F46E5"/><path d="M1379 400 l9 8 l-9 8 M1389 400 l9 8 l-9 8" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/><text x="1390" y="446" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">LLM Gateway</text><text x="1390" y="459" text-anchor="middle" font-size="9.5" fill="#5A6B7B">LiteLLM · IP allow-list</text>
+<rect x="1517.0" y="385.0" width="46" height="46" rx="8" fill="#4F46E5"/><path d="M1529 400 l9 8 l-9 8 M1539 400 l9 8 l-9 8" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/><text x="1540" y="446" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">LLM Gateway</text><text x="1540" y="459" text-anchor="middle" font-size="9.5" fill="#5A6B7B">LiteLLM · IP allow-list</text>
 <g transform="translate(307.00,145.00) scale(0.5750)">
 
     
@@ -291,11 +299,23 @@
         </g>
     </g>
 </g><text x="1220" y="698" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">Amazon Bedrock</text><text x="1220" y="711" text-anchor="middle" font-size="9.5" fill="#5A6B7B">alt: direct · global. CRIS</text>
+<g transform="translate(1367.00,277.00) scale(0.7188)">
+<g clip-path="url(#agentcore__clip0_211_72)">
+<rect width="64" height="64" fill="#01A88D"/>
+<path d="M53.3721 21.0727L50.8965 20.0801L49.9326 17.6343C49.7812 17.2519 49.4131 17.001 49.0019 17.001C48.5908 17.0015 48.2217 17.2529 48.0713 17.6357L47.0976 20.1157L44.6377 21.0703C44.2529 21.2197 43.999 21.5913 44 22.0049C44.0009 22.4184 44.2568 22.7891 44.6426 22.9365L47.1553 23.897L48.0625 26.3481C48.2051 26.7353 48.5723 26.9946 48.9853 27.001H49C49.4072 27.001 49.7744 26.7539 49.9277 26.375L50.9385 23.8686L53.3603 22.9341C53.7432 22.7856 53.9971 22.4184 54 22.0073C54.0029 21.5967 53.7539 21.2256 53.3721 21.0727ZM49.8135 22.1592C49.5557 22.2593 49.3496 22.4614 49.2461 22.7183L49.04 23.2285L48.873 22.7773C48.7734 22.5073 48.5615 22.2934 48.293 22.1904L47.7822 21.9951L48.2305 21.8213C48.4902 21.7202 48.6973 21.5146 48.7988 21.2544L49.0039 20.7319L49.1592 21.1265C49.25 21.437 49.4883 21.6855 49.793 21.792L50.2695 21.9834L49.8135 22.1592ZM51.2148 30.853L44.0078 27.9629L41.1973 20.8379C41.0078 20.3569 40.5508 20.0459 40.0342 20.0459C39.5166 20.0464 39.0586 20.3574 38.8701 20.8394L36.0312 28.0747L33.0011 29.2507L33.0019 13.998C33.0019 13.6191 32.788 13.2729 32.4492 13.1035L26.4472 10.1055C26.1513 9.95849 25.8027 9.96581 25.5146 10.126L16.5146 15.126C16.1972 15.3022 16 15.6367 16 16V23.3818L10.5527 26.1055C10.2138 26.2749 9.99997 26.6211 9.99997 27V37C9.99997 37.3511 10.1845 37.6768 10.4853 37.8574L15 40.5664V47C15 47.3657 15.2002 47.7026 15.5214 47.8779L26.5215 53.8779C26.6709 53.9594 26.8349 54 27 54C27.1787 54 27.3564 53.9521 27.5146 53.8574L32.5146 50.8574C32.8154 50.6767 33 50.351 33 50L33.0008 34.7649L36.2138 35.9927L38.8662 43.1616C39.0459 43.6494 39.499 43.9697 40.0185 43.9775C40.0253 43.9775 40.0322 43.978 40.039 43.978C40.5507 43.978 41.0039 43.6733 41.1982 43.1953L44.1396 35.9053L51.1992 33.1797C51.6816 32.9941 51.9961 32.5395 52 32.022C52.0029 31.5044 51.6953 31.0454 51.2148 30.853ZM26.9766 51.8481L23.7745 50.1015L27.5146 47.8574L26.4853 46.1426L21.7383 48.9908L17 46.4062V40.5662L21.5146 37.8574L20.4853 36.1426L16 38.8338L12 36.4336V32.6182L17.4472 29.8945L16.5527 28.1055L12 30.3818V27.6182L16.9563 25.14L21 27.5662V30.3818L17.5527 32.1055L18.4472 33.8945L22.0026 32.1169L25.5566 33.877L26.4433 32.085L23 30.3797V27.5664L27.5146 24.8574C27.8154 24.6768 28 24.3511 28 24V19H26V23.4336L22 25.8338L18 23.4338V16.5884L21 14.9217V21H23V13.8106L26.0244 12.1304L31.0019 14.6162L31.0007 36.4504L20.4629 43.1563L21.5371 44.8438L31.0006 38.8215L31 49.4336L26.9766 51.8481ZM43.0146 34.1953C42.7568 34.2954 42.5508 34.4976 42.4473 34.7544L40.0683 40.6494L37.9316 34.8735C37.832 34.6035 37.6201 34.3896 37.3516 34.2866L33.0009 32.6238L33.001 31.3955L37.1631 29.7803C37.4238 29.6792 37.6308 29.4736 37.7324 29.2134L40.0361 23.3438L42.2431 28.9385C42.3183 29.2905 42.5849 29.5747 42.9258 29.6841L48.7021 32L43.0146 34.1953Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="agentcore__clip0_211_72">
+<rect width="64" height="64" fill="white"/>
+</clipPath>
+</defs>
+</g><text x="1390" y="338" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">AgentCore Gateway</text><text x="1390" y="351" text-anchor="middle" font-size="9.5" fill="#5A6B7B">existing APIs as MCP tools</text>
+<rect x="1517.0" y="277.0" width="46" height="46" rx="8" fill="#475569"/><circle cx="1537" cy="297" r="8" fill="none" stroke="#fff" stroke-width="2.6"/><line x1="1543" y1="303" x2="1550" y2="310" stroke="#fff" stroke-width="2.8" stroke-linecap="round"/><text x="1540" y="338" text-anchor="middle" font-size="13" font-weight="700" fill="#16202E">Existing APIs</text><text x="1540" y="351" text-anchor="middle" font-size="9.5" fill="#5A6B7B">SSO-capable · or not yet</text>
 <circle cx="211" cy="408" r="9" fill="#232F3E"/><text x="211" y="411" text-anchor="middle" font-size="10.5" font-weight="700" fill="#fff">1</text>
 <circle cx="450" cy="408" r="9" fill="#232F3E"/><text x="450" y="411" text-anchor="middle" font-size="10.5" font-weight="700" fill="#fff">2</text>
 <circle cx="700" cy="408" r="9" fill="#232F3E"/><text x="700" y="411" text-anchor="middle" font-size="10.5" font-weight="700" fill="#fff">3</text>
 <circle cx="955" cy="408" r="9" fill="#232F3E"/><text x="955" y="411" text-anchor="middle" font-size="10.5" font-weight="700" fill="#fff">4</text>
-<circle cx="1235" cy="408" r="9" fill="#232F3E"/><text x="1235" y="411" text-anchor="middle" font-size="10.5" font-weight="700" fill="#fff">5</text>
+<circle cx="1310" cy="408" r="9" fill="#232F3E"/><text x="1310" y="411" text-anchor="middle" font-size="10.5" font-weight="700" fill="#fff">5</text>
 <text x="40" y="810" font-size="11" font-weight="700" fill="#16202E">Flows</text>
 <circle cx="92" cy="806" r="5" fill="#1D4ED8"/><text x="102" y="810" font-size="10.5" fill="#5A6B7B">request →</text>
 <circle cx="185" cy="806" r="5" fill="#0F766E"/><text x="195" y="810" font-size="10.5" fill="#5A6B7B">reply ←</text>


### PR DESCRIPTION
The gateway is now a first-class platform capability (Gateway page, registry identity forwarding, published-agent story), so the overall architecture diagram should show it. Adds: headless kernel → **AgentCore Gateway** (MCP, caller's own token) → **existing enterprise APIs** (OBO token / API key outbound), placed inside AWS Cloud / outside the VPC. Canvas widened 1480→1620; the full enforcement-model detail stays in [docs/images/authorization-layers.svg](docs/images/authorization-layers.svg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)