### PR TITLE
Fix service-entry deployment trigger rejecting its own plan

### DIFF
--- a/terraform/modules/portal/service_entry.tf
+++ b/terraform/modules/portal/service_entry.tf
@@ -183,7 +183,11 @@ resource "aws_api_gateway_deployment" "service_entry" {
       aws_api_gateway_method.poll.id,
       aws_api_gateway_integration.submit.uri,
       aws_api_gateway_integration.poll.uri,
-      aws_api_gateway_rest_api.service_entry.policy,
+      # the policy *input*, not rest_api.policy: API Gateway normalises the
+      # document it stores, so reading it back yields a different string during
+      # apply than at plan time and the provider rejects its own plan
+      # ("produced an invalid new value for .triggers").
+      data.aws_iam_policy_document.service_entry_api.json,
     ]))
   }
 


### PR DESCRIPTION
Fixes #4.

`aws_api_gateway_deployment.service_entry` hashed
`aws_api_gateway_rest_api.service_entry.policy` into its redeployment trigger.
That attribute is the policy document API Gateway *stores*, and the service
normalises it, so the string read during apply differs from the one seen at plan
time — the trigger changes mid-apply and the provider rejects its own plan
("produced an invalid new value for .triggers"). The apply halts with the stage
still on its previous deployment.

It stays hidden on a first apply, where both hashes derive from the same unknown
value; it only fires on a later apply that changes something else in the trigger
set.

This hashes the policy input (`data.aws_iam_policy_document.service_entry_api.json`)
instead — the same document before the round-trip, so stable between plan and
apply while still changing whenever the policy changes.

## Verification

- `terraform validate` passes.
- Applied against a live deployment: the previously failing apply now completes,
  and the deployment/stage update as intended.

## Note

The stage is a `create_before_destroy` resource, so applying this replaces the
deployment once (expected — it is a stateless object; the trigger's whole job is
to force that replacement).
