### PR TITLE
Harden the deployment: origin trust, CORS scope, audit logging, data recovery

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -7,3 +7,4 @@ terraform.tfvars
 modules/portal/.schedule-runner-placeholder.zip
 imports_adoption.tf
 backend.tf
+tfplan-*

--- a/terraform/modules/platform/main.tf
+++ b/terraform/modules/platform/main.tf
@@ -20,6 +20,44 @@ resource "aws_s3_bucket" "workspace" {
   bucket = "agent-platform-workspaces-${local.account}-${local.region}${var.name_suffix}"
 }
 
+# Session workspaces and skill packages live here. Versioning turns a bad
+# sync (or a destructive agent) from data loss into a recoverable event.
+resource "aws_s3_bucket_versioning" "workspace" {
+  bucket = aws_s3_bucket.workspace.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# The kernels sync with multipart uploads; abandoned parts bill silently.
+resource "aws_s3_bucket_lifecycle_configuration" "workspace" {
+  bucket = aws_s3_bucket.workspace.id
+
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  # Keep recovery useful without unbounded growth.
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "workspace" {
   bucket = aws_s3_bucket.workspace.id
 
@@ -74,6 +112,17 @@ resource "aws_dynamodb_table" "platform" {
   hash_key     = "PK"
   range_key    = "SK"
 
+  # The table is the whole control plane: sessions, published agents, the
+  # registry, channels, schedules, the invocation ledger and the audit trail.
+  # Without PITR an accidental overwrite or a bad migration is unrecoverable.
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true # AWS-owned key; set kms_key_arn for a CMK
+  }
+
   attribute {
     name = "PK"
     type = "S"
@@ -93,6 +142,12 @@ resource "aws_ecr_repository" "kernel" {
 
   name         = "agent-platform${var.name_suffix}/${each.key}"
   force_delete = true
+
+  # Kernel images run agent code with an IAM role attached; a scan on push is
+  # the cheapest place to catch a vulnerable base layer.
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 }
 
 resource "aws_ecr_repository" "team_auth" {
@@ -100,6 +155,10 @@ resource "aws_ecr_repository" "team_auth" {
 
   name         = "agent-platform${var.name_suffix}/${each.key}"
   force_delete = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 }
 
 # ------------------------- LLM gateway secret ------------------------------

--- a/terraform/modules/portal/ecs.tf
+++ b/terraform/modules/portal/ecs.tf
@@ -225,7 +225,11 @@ locals {
       PLATFORM_SDK_RUNTIME_ARN           = var.sdk_runtime_arn
       PLATFORM_MCP_TOOLS_RUNTIME_ARN     = var.mcp_tools_runtime_arn
       PLATFORM_WORKSPACE_ACCESS_ROLE_ARN = var.workspace_access_role_arn
-      PLATFORM_CORS_ORIGINS              = "*"
+      # Scoped to the portal's own origin. A wildcard here is reflected back
+      # with Access-Control-Allow-Credentials, which would let any site read
+      # authenticated API responses the moment the portal moves its token
+      # out of localStorage into a cookie.
+      PLATFORM_CORS_ORIGINS              = "https://${aws_cloudfront_distribution.portal.domain_name}"
       PLATFORM_COGNITO_POOL_ID           = aws_cognito_user_pool.portal.id
       PLATFORM_COGNITO_CLIENT_ID         = aws_cognito_user_pool_client.portal.id
       PLATFORM_SCHEDULER_GROUP           = aws_scheduler_schedule_group.portal.name
@@ -343,6 +347,16 @@ resource "aws_lb" "portal" {
   internal           = false
   security_groups    = [aws_security_group.alb.id]
   subnets            = var.public_subnet_ids
+
+  drop_invalid_header_fields = true
+
+  access_logs {
+    bucket  = aws_s3_bucket.logs.id
+    prefix  = "alb"
+    enabled = true
+  }
+
+  depends_on = [aws_s3_bucket_policy.logs]
 }
 
 resource "aws_lb_target_group" "backend" {
@@ -361,14 +375,42 @@ resource "aws_lb_target_group" "backend" {
   }
 }
 
+# The security group admits the CloudFront origin-facing prefix list, which
+# covers EVERY CloudFront distribution — not just this one. So the listener
+# denies by default and forwards only requests carrying the secret header that
+# this distribution injects (see aws_cloudfront_distribution.portal). Without
+# it, anyone could point their own distribution at this ALB's DNS name and
+# reach the backend directly, bypassing the intended edge.
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.portal.arn
   port              = 80
   protocol          = "HTTP"
 
   default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Direct origin access is not allowed."
+      status_code  = "403"
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "from_cloudfront" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 100
+
+  action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.backend.arn
+  }
+
+  condition {
+    http_header {
+      http_header_name = "x-origin-verify"
+      values           = [random_password.origin_verify.result]
+    }
   }
 }
 

--- a/terraform/modules/portal/main.tf
+++ b/terraform/modules/portal/main.tf
@@ -8,6 +8,14 @@ locals {
   region  = data.aws_region.current.region
 }
 
+# Shared secret proving an ALB request arrived via this CloudFront
+# distribution. Lives in state like the service-entry secret — protect the
+# state file (see terraform/README.md).
+resource "random_password" "origin_verify" {
+  length  = 48
+  special = false
+}
+
 # ------------------------------- auth --------------------------------------
 # Cognito user pool guarding the portal. Self-signup is disabled — an
 # operator creates users (admin-create-user).
@@ -63,6 +71,112 @@ resource "aws_cognito_user_group" "admin" {
   name         = "platform-admin"
   user_pool_id = aws_cognito_user_pool.portal.id
   description  = "Agent Platform administrators"
+}
+
+# ------------------------------ access logs --------------------------------
+# The application ledger records intended platform calls; these record raw
+# HTTP, which is what an incident review needs (and what the security review
+# flagged as missing). ACLs are required by both CloudFront log delivery and
+# the ALB log-delivery principal, hence ObjectWriter ownership.
+
+resource "aws_s3_bucket" "logs" {
+  bucket        = "agent-platform-logs-${local.account}-${local.region}${var.name_suffix}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "expire"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = 90
+    }
+  }
+}
+
+# Regional ALB log-delivery account (ELB writes with an account principal, not
+# a service principal, in every region that predates the service-principal
+# model).
+data "aws_elb_service_account" "current" {}
+
+data "aws_iam_policy_document" "logs_bucket" {
+  statement {
+    sid     = "AlbLogDelivery"
+    actions = ["s3:PutObject"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_elb_service_account.current.arn]
+    }
+    resources = ["${aws_s3_bucket.logs.arn}/alb/*"]
+  }
+
+  statement {
+    sid     = "AlbLogDeliveryAclCheck"
+    actions = ["s3:GetBucketAcl"]
+    principals {
+      type        = "Service"
+      identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+    resources = [aws_s3_bucket.logs.arn]
+  }
+
+  statement {
+    sid     = "EnforceTLS"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.logs.arn,
+      "${aws_s3_bucket.logs.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  policy = data.aws_iam_policy_document.logs_bucket.json
+
+  depends_on = [aws_s3_bucket_public_access_block.logs]
 }
 
 # ------------------------------ frontend -----------------------------------
@@ -160,6 +274,13 @@ resource "aws_cloudfront_distribution" "portal" {
     origin_id   = local.api_origin_id
     domain_name = aws_lb.portal.dns_name
 
+    # Proves to the ALB that a request really came through this distribution;
+    # the ALB listener rejects anything without it (see ecs.tf).
+    custom_header {
+      name  = "x-origin-verify"
+      value = random_password.origin_verify.result
+    }
+
     custom_origin_config {
       origin_protocol_policy = "http-only"
       http_port              = 80
@@ -217,8 +338,17 @@ resource "aws_cloudfront_distribution" "portal" {
     }
   }
 
+  logging_config {
+    bucket          = aws_s3_bucket.logs.bucket_domain_name
+    prefix          = "cloudfront/"
+    include_cookies = false
+  }
+
   viewer_certificate {
     cloudfront_default_certificate = true
+    # NB: with the default CloudFront certificate AWS pins the viewer TLS
+    # policy and rejects minimum_protocol_version; set it alongside an ACM
+    # certificate when you attach a custom domain.
   }
 }
 

--- a/terraform/modules/portal/service_entry.tf
+++ b/terraform/modules/portal/service_entry.tf
@@ -233,10 +233,47 @@ resource "aws_api_gateway_deployment" "service_entry" {
   ]
 }
 
+# The service entry is the server-to-server front door: every call is an
+# external workload acting on a channel, so the access log is the only record
+# of who called before the request reaches the application ledger.
+#
+# PREREQUISITE (account-level, one-time, idempotent): API Gateway can only
+# write logs once the account has a CloudWatch role configured. Terraform
+# cannot set it per-stack, so if the stage fails to create with
+# "CloudWatch Logs role ARN must be set in account settings", run:
+#
+#   aws apigateway update-account --patch-operations \
+#     op=replace,path=/cloudwatchRoleArn,value=<role-arn>
+#
+# where the role trusts apigateway.amazonaws.com and carries
+# AmazonAPIGatewayPushToCloudWatchLogs.
+resource "aws_cloudwatch_log_group" "service_entry_access" {
+  name              = "/aws/apigateway/agent-platform-service-entry${var.name_suffix}"
+  retention_in_days = 30
+}
+
 resource "aws_api_gateway_stage" "svc" {
   rest_api_id   = aws_api_gateway_rest_api.service_entry.id
   deployment_id = aws_api_gateway_deployment.service_entry.id
   stage_name    = "svc"
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.service_entry_access.arn
+    # the caller identity SigV4 established, plus enough to correlate with the
+    # application ledger
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      callerArn      = "$context.identity.userArn"
+      vpce           = "$context.identity.vpceId"
+      httpMethod     = "$context.httpMethod"
+      resourcePath   = "$context.resourcePath"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+      requestTime    = "$context.requestTime"
+      integrationErr = "$context.integration.error"
+    })
+  }
 }
 
 resource "aws_api_gateway_method_settings" "svc" {


### PR DESCRIPTION
Addresses #6.

Five independent configuration gaps, grouped because each is a few lines of
Terraform in the same two modules. Rationale for each is in the commit message;
summary here.

| Gap | Change |
|---|---|
| ALB reachable from any CloudFront distribution | distribution injects `x-origin-verify`; listener default-denies 403 and forwards only on that header |
| `CORS = "*"` with `allow_credentials` | scoped to the distribution domain |
| No raw-HTTP audit trail | log bucket + CloudFront/ALB access logs + API Gateway stage JSON logs (caller ARN, source VPCE) |
| No recovery path | DynamoDB PITR + SSE; workspace bucket versioning, noncurrent expiry, MPU cleanup; ECR scan-on-push |
| Secrets in unencrypted local state | `backend.tf.example`: encrypted S3 backend, versioning, locking, bootstrap commands |

## Verification

`terraform validate` passes; applied against a live deployment. After apply:

- portal still serves 200 through CloudFront; `/health` responds
- a request carrying a foreign `Origin` comes back with **no**
  `Access-Control-Allow-Origin` header
- the ALB listener shows the `forward` rule conditioned on `x-origin-verify`
  with a 403 `fixed-response` default
- PITR, bucket versioning and ECR scan-on-push are enabled

Zero destroys in the plan; the only replacements are the API Gateway deployment
and the ECS task definition, both stateless.

## Heads-up for reviewers

API Gateway will not create a logging stage until the **account** has
`cloudwatchRoleArn` set — Terraform cannot do that per-stack. I hit it on a clean
account, so the command is documented inline in `service_entry.tf` rather than
leaving the next person with the (fairly opaque) error.

The `x-origin-verify` value also lands in state, same as the existing
service-entry secret — hence the backend example in the same PR.
