### PR TITLE
Run the backend on two tasks with deployment rollback

### DIFF
--- a/terraform/modules/portal/ecs.tf
+++ b/terraform/modules/portal/ecs.tf
@@ -417,8 +417,17 @@ resource "aws_ecs_service" "backend" {
   name            = "agent-platform-backend${var.name_suffix}"
   cluster         = aws_ecs_cluster.portal.id
   task_definition = aws_ecs_task_definition.backend.arn
-  desired_count   = 1
-  launch_type     = "FARGATE"
+  # Two tasks across the two private subnets: the control plane is in the path
+  # of every portal call and every scheduled invocation, and a single task makes
+  # each deploy a brief outage. Raise with autoscaling if invoke volume grows.
+  desired_count = 2
+  launch_type   = "FARGATE"
+
+  # Roll back automatically instead of leaving the service wedged on a bad image.
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   network_configuration {
     subnets          = var.private_subnet_ids


### PR DESCRIPTION
The backend is the control plane: every portal API call, every scheduled
invocation, every channel and service-entry request goes through it. At
`desired_count = 1` there is one task, so a rolling deploy or a task replacement
is a brief outage of all of them, and an AZ event takes the portal down until
Fargate reschedules elsewhere.

This runs two tasks — the service already lists both private subnets, so they
spread across AZs with no further change — and enables the deployment circuit
breaker with rollback, so a task that never reaches a steady state reverts
instead of leaving the service wedged (the failure mode when a pushed image is
broken).

Kept as a fixed count rather than autoscaling: the sample has no load profile to
target a policy at, and two is what removes the single point of failure. Roughly
doubles the Fargate line item for the backend task (the NAT Gateway remains the
dominant standing cost) — say the word if you'd rather have this behind a
variable defaulting to 1.

## Verification

`terraform validate` passes; applied against a live deployment. The service
converged to 2/2 running on a single deployment revision, and the portal stayed
reachable throughout the rollout.
