### PR TITLE
Derive the memory actor from the caller instead of the request

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -88,7 +88,7 @@ def delete_agent(agent_id: str, user: Principal = Depends(get_current_user)):
 
 
 @router.post("/{agent_id}/invoke", response_model=InvokeResponse)
-def invoke_agent(agent_id: str, req: AgentInvokeRequest, user: str = Depends(get_current_user)):
+def invoke_agent(agent_id: str, req: AgentInvokeRequest, user: Principal = Depends(get_current_user)):
     try:
         return invocation_service.invoke(
             user=user,
@@ -96,7 +96,11 @@ def invoke_agent(agent_id: str, req: AgentInvokeRequest, user: str = Depends(get
             target=f"agent:{agent_id}",
             prompt=req.prompt,
             runtime_session_id=req.session_id,
-            memory_actor_id=req.memory_actor_id,
+            # a published agent carries its own memory_id, so the actor ID is
+            # the only thing standing between callers' memory lines
+            memory_actor_id=invocation_service.resolve_memory_actor(
+                user, req.memory_actor_id
+            ),
             memory_last_k_turns=req.memory_last_k_turns,
         )
     except KeyError:

--- a/backend/app/api/kernels.py
+++ b/backend/app/api/kernels.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.dependencies import get_current_user
+from app.dependencies import Principal, get_current_user
 from app.models.schemas import InvokeRequest, InvokeResponse, KernelInfo
 from app.services import invocation_service
 from app.services.governance_service import QuotaExceeded, SourceDisabled
@@ -17,7 +17,7 @@ def list_kernels(user: str = Depends(get_current_user)):
 
 
 @router.post("/agent-sdk/invoke", response_model=InvokeResponse)
-def invoke_sdk_kernel(req: InvokeRequest, user: str = Depends(get_current_user)):
+def invoke_sdk_kernel(req: InvokeRequest, user: Principal = Depends(get_current_user)):
     try:
         return invocation_service.invoke(
             user=user,
@@ -30,7 +30,11 @@ def invoke_sdk_kernel(req: InvokeRequest, user: str = Depends(get_current_user))
             mcp_server_ids=req.mcp_server_ids,
             skill_ids=req.skill_ids,
             memory_id=req.memory_id,
-            memory_actor_id=req.memory_actor_id,
+            # the actor ID selects whose memory is retrieved — never take it
+            # from the request verbatim (see resolve_memory_actor)
+            memory_actor_id=invocation_service.resolve_memory_actor(
+                user, req.memory_actor_id
+            ),
             memory_last_k_turns=req.memory_last_k_turns,
         )
     except (QuotaExceeded, SourceDisabled) as e:

--- a/backend/app/services/invocation_service.py
+++ b/backend/app/services/invocation_service.py
@@ -32,6 +32,35 @@ class IdentityRequired(Exception):
     path has no end-user token (internal caller, or non-OIDC auth mode)."""
 
 
+def resolve_memory_actor(user, requested: str) -> str:
+    """Map a *request-supplied* memory actor onto one the caller may address.
+
+    AgentCore Memory keys long-term records by actor (``/users/{actorId}``),
+    so the actor ID is an authorization boundary, not a label: whoever picks
+    it decides whose memory the kernel retrieves and injects into the system
+    prompt. Callers must therefore never set it verbatim — an ordinary user
+    passing another user's ID would otherwise read that user's records, which
+    the admin-only memory browsing API exists to prevent.
+
+    A user still has a legitimate reason to want more than one memory line
+    (one per project, say), so a supplied value is *namespaced under the
+    caller* rather than rejected. Admins keep verbatim addressing, matching
+    the memory-browsing surface they already hold.
+
+    NB: applied at the API boundary, not inside :func:`invoke`. Internal
+    callers (channels, the service entry) derive their actor server-side from
+    data the caller cannot forge — ``chn-{channel_id}-{conversation_id}`` —
+    and must reach ``invoke`` unmodified to keep an existing conversation's
+    memory line stable.
+    """
+    caller = str(user)
+    if not requested or requested == caller:
+        return caller
+    if getattr(user, "is_admin", False):
+        return requested
+    return f"{caller}:{requested}"
+
+
 def forward_identity(mcp_servers: list[dict]) -> list[dict]:
     """Resolve ``{{user_token}}`` in attachment headers to the caller's token.
 

--- a/backend/app/services/workspace_credentials_service.py
+++ b/backend/app/services/workspace_credentials_service.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 # Role chaining (task role → workspace-access role) caps sessions at 1h.
 CREDS_DURATION_S = 3600
 
+# Partition holding runtime_session_id -> refresh-token lookup items.
+WS_TOKEN_PK = "WSTOKEN"
+
 
 def _session_policy(runtime_session_id: str) -> str:
     import json
@@ -101,14 +104,35 @@ class WorkspaceCredentialsService:
     # ------------------------------------------------ refresh-token flow
 
     def issue_refresh_token(self, user: str, session_id: str) -> str:
-        """Mint (or rotate) the per-session refresh token. Stored on the
-        session item; sent to the container only inside the warmup payload."""
+        """Mint (or rotate) the per-session refresh token.
+
+        Written twice: onto the session item (where the portal reads it) and
+        into a lookup item keyed by ``runtime_session_id``, which is what the
+        container presents on refresh. The lookup item is what lets
+        :meth:`refresh` be a ``get_item`` rather than a table scan — a filtered
+        scan reads a single 1 MB page, so once this shared table grows past
+        that the matching session stops being found and workspace sync dies
+        silently after the first hour (role chaining caps credentials at 1 h).
+        """
         token = secrets.token_urlsafe(32)
-        self.table.update_item(
+        attrs = self.table.update_item(
             Key={"PK": f"USER#{user}", "SK": f"SESSION#{session_id}"},
             UpdateExpression="SET ws_refresh_token = :t",
             ExpressionAttributeValues={":t": token},
-        )
+            ReturnValues="ALL_NEW",
+        ).get("Attributes", {})
+        runtime_session_id = str(attrs.get("runtime_session_id", ""))
+        if runtime_session_id:
+            self.table.put_item(
+                Item={
+                    "PK": WS_TOKEN_PK,
+                    "SK": f"RSID#{runtime_session_id}",
+                    "ws_refresh_token": token,
+                    "runtime_session_id": runtime_session_id,
+                    "user": user,
+                    "session_id": session_id,
+                }
+            )
         return token
 
     def refresh(self, runtime_session_id: str, token: str) -> dict | None:
@@ -120,17 +144,49 @@ class WorkspaceCredentialsService:
         """
         if not runtime_session_id or not token:
             return None
-        resp = self.table.scan(
-            FilterExpression="runtime_session_id = :r",
-            ExpressionAttributeValues={":r": runtime_session_id},
-        )
-        items = resp.get("Items", [])
-        if len(items) != 1:
-            return None
-        expected = items[0].get("ws_refresh_token", "")
+        expected = self._lookup_token(runtime_session_id)
         if not expected or not hmac.compare_digest(expected, token):
             return None
         return self.mint(runtime_session_id)
+
+    def _lookup_token(self, runtime_session_id: str) -> str:
+        """The stored refresh token for a runtime session, or "".
+
+        Direct key read. Sessions created before the lookup item existed fall
+        back to a fully paginated scan, so a workspace already in flight keeps
+        refreshing across a deploy of this change; the fallback stops being
+        reachable once those sessions expire.
+        """
+        item = self.table.get_item(
+            Key={"PK": WS_TOKEN_PK, "SK": f"RSID#{runtime_session_id}"}
+        ).get("Item")
+        if item:
+            return str(item.get("ws_refresh_token", ""))
+        return self._legacy_scan_token(runtime_session_id)
+
+    def _legacy_scan_token(self, runtime_session_id: str) -> str:
+        """Pre-migration fallback: walk every page. The original single-page
+        scan silently missed sessions once the table exceeded 1 MB, and treated
+        "more than one match" and "no match" alike — both still fail closed."""
+        kwargs: dict = {
+            "FilterExpression": "runtime_session_id = :r",
+            "ExpressionAttributeValues": {":r": runtime_session_id},
+        }
+        found: list[dict] = []
+        while True:
+            resp = self.table.scan(**kwargs)
+            found.extend(i for i in resp.get("Items", []) if i.get("ws_refresh_token"))
+            if len(found) > 1:
+                logger.error(
+                    "ambiguous runtime_session_id %s — refusing to mint credentials",
+                    runtime_session_id,
+                )
+                return ""
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                break
+            kwargs["ExclusiveStartKey"] = start_key
+        return str(found[0].get("ws_refresh_token", "")) if len(found) == 1 else ""
 
 
 workspace_credentials_service = WorkspaceCredentialsService()

--- a/scripts/check_memory_actor_authz.py
+++ b/scripts/check_memory_actor_authz.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Authorization checks for the memory actor boundary.
+
+The actor ID selects whose AgentCore Memory records get retrieved and injected
+into the kernel system prompt, so it is an authorization boundary rather than a
+label. This script asserts a request-supplied value can never address another
+principal memory line.
+
+Runs with no third-party dependencies and makes no AWS calls, so it is safe in
+CI: resolve_memory_actor is read straight out of the module source and executed
+in isolation, avoiding the FastAPI/boto3 import chain the package normally pulls.
+
+Run: python3 scripts/check_memory_actor_authz.py
+"""
+
+import ast
+import os
+import sys
+
+SRC = os.path.join(
+    os.path.dirname(__file__), "..", "backend", "app", "services", "invocation_service.py"
+)
+FUNC = "resolve_memory_actor"
+
+
+def load_function():
+    """Exec just the target function, so importing the service (boto3, FastAPI)
+    is not required."""
+    with open(SRC, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == FUNC:
+            module = ast.Module(body=[node], type_ignores=[])
+            namespace: dict = {}
+            exec(compile(module, SRC, "exec"), namespace)  # noqa: S102 - own source
+            return namespace[FUNC]
+    raise SystemExit(f"{FUNC} not found in {SRC} — did the fix get reverted?")
+
+
+resolve_memory_actor = load_function()
+
+
+class FakePrincipal(str):
+    """Stands in for app.dependencies.Principal (a str subclass + is_admin)."""
+
+    is_admin = False
+
+
+def _user(name, admin=False):
+    p = FakePrincipal(name)
+    p.is_admin = admin
+    return p
+
+
+FAILURES = []
+
+
+def check(label, actual, expected):
+    ok = actual == expected
+    if not ok:
+        FAILURES.append(f"{label}: expected {expected!r}, got {actual!r}")
+    print(f"  {'ok  ' if ok else 'FAIL'} {label}")
+
+
+alice = _user("alice")
+admin = _user("admin", admin=True)
+
+print("ordinary user:")
+# the case that matters: another principal's actor must not be addressable
+check("cannot address another user actor", resolve_memory_actor(alice, "admin"), "alice:admin")
+check("empty request falls back to caller", resolve_memory_actor(alice, ""), "alice")
+check("own name stays unprefixed", resolve_memory_actor(alice, "alice"), "alice")
+check("extra memory lines stay under caller", resolve_memory_actor(alice, "proj-x"), "alice:proj-x")
+# a crafted value must not escape the caller namespace by re-prefixing
+check("cannot forge a nested actor", resolve_memory_actor(alice, "bob:proj"), "alice:bob:proj")
+
+print("administrator:")
+check("keeps verbatim addressing", resolve_memory_actor(admin, "alice"), "alice")
+check("empty request falls back to caller", resolve_memory_actor(admin, ""), "admin")
+
+if FAILURES:
+    print("\nFAILED:")
+    for f in FAILURES:
+        print(" -", f)
+    sys.exit(1)
+print("\nall memory-actor authorization checks passed")


### PR DESCRIPTION
Two places in the headless invocation path take a caller-supplied value where a
server-derived one belongs.

## Memory actor

`memory_actor_id` travels from the request body into the AgentCore Memory
namespace (`/users/{actorId}`) that the kernel retrieves from before a run, so it
decides whose long-term records get injected into the system prompt. That makes
it an authorization input rather than a label.

`invocation_service.invoke` defaulted it with `memory_actor_id or user`, which
reads like ownership enforcement but is only a fallback — an explicitly supplied
value wins. Since the portal's memory browsing API is `require_admin`, the invoke
path was the looser of the two ways to reach the same records, which looks
unintended.

`resolve_memory_actor` now namespaces a supplied value under the caller
(`alice` asking for `bob` gets `alice:bob`) instead of rejecting it: wanting
several memory lines — one per project — is a legitimate use, and rejecting
outright would remove it. Admins keep verbatim addressing, matching the browsing
surface they already have.

Applied at the two API boundaries rather than inside `invoke()` deliberately:
channels and the service entry derive their actor server-side from data the
caller cannot forge (`chn-{channel_id}-{conversation_id}`) and need to keep
reaching `invoke` unchanged, so that an existing conversation stays on its own
memory line.

`scripts/check_memory_actor_authz.py` covers the boundary, including that a
crafted value cannot re-prefix its way out of the caller's namespace. It parses
the function out of the module and runs it in isolation, so it needs no
third-party packages and makes no AWS calls — safe for CI.

## Workspace refresh tokens

`refresh()` located a session with a filtered `table.scan()` and required exactly
one match. A filtered scan reads a single 1 MB page of *pre-filter* data, and
this table is shared by sessions, channels, ledger entries and audit records — so
once it grows past that, the matching session stops being found, every refresh
401s, and interactive workspaces quietly stop syncing to S3 after the first hour
(role chaining caps the credentials at 1 h). Work is lost with nothing surfaced
in the UI. It also rested on a `runtime_session_id` uniqueness that no key or
index enforces.

`issue_refresh_token` now also writes a lookup item keyed by
`runtime_session_id`, making `refresh` a `get_item`. Chose that over a GSI because
adding an index to a live table is the heavier change and this drops the
uniqueness assumption outright.

Sessions predating the change fall back to a **fully paginated** scan (the
original walked only page 1), so a workspace already in flight keeps refreshing
across the deploy; that path stops being reachable once those sessions expire,
and it now fails closed with a log line on an ambiguous match instead of
silently.

## Verification

Applied to a live deployment and exercised end to end:

- `scripts/check_memory_actor_authz.py` passes — and I confirmed it *fails* when
  the previous behaviour is restored, so it is a real regression guard
- an ordinary user's supplied actor lands in their own namespace, while the
  owner's own memory retrieval keeps working (checked both directions: the point
  was to scope retrieval, not break it)
- creating and connecting an interactive session still mints workspace
  credentials and a `wss://` URL, and the lookup item appears in DynamoDB

## Follow-up, not in this PR

The refresh token is never rotated or expired — minted per connect and stored on
the session item indefinitely. Out of scope here; worth its own change.
