### PR TITLE
Backend availability and caller-scoped authorization fixes

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -88,7 +88,7 @@ def delete_agent(agent_id: str, user: Principal = Depends(get_current_user)):
 
 
 @router.post("/{agent_id}/invoke", response_model=InvokeResponse)
-def invoke_agent(agent_id: str, req: AgentInvokeRequest, user: str = Depends(get_current_user)):
+def invoke_agent(agent_id: str, req: AgentInvokeRequest, user: Principal = Depends(get_current_user)):
     try:
         return invocation_service.invoke(
             user=user,
@@ -96,7 +96,11 @@ def invoke_agent(agent_id: str, req: AgentInvokeRequest, user: str = Depends(get
             target=f"agent:{agent_id}",
             prompt=req.prompt,
             runtime_session_id=req.session_id,
-            memory_actor_id=req.memory_actor_id,
+            # a published agent carries its own memory_id, so the actor ID is
+            # all that separates callers' memory lines (see resolve_memory_actor)
+            memory_actor_id=invocation_service.resolve_memory_actor(
+                user, req.memory_actor_id
+            ),
             memory_last_k_turns=req.memory_last_k_turns,
         )
     except KeyError:

--- a/backend/app/api/kernels.py
+++ b/backend/app/api/kernels.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.dependencies import get_current_user
+from app.dependencies import Principal, get_current_user
 from app.models.schemas import InvokeRequest, InvokeResponse, KernelInfo
 from app.services import invocation_service
 from app.services.governance_service import QuotaExceeded, SourceDisabled
@@ -17,7 +17,7 @@ def list_kernels(user: str = Depends(get_current_user)):
 
 
 @router.post("/agent-sdk/invoke", response_model=InvokeResponse)
-def invoke_sdk_kernel(req: InvokeRequest, user: str = Depends(get_current_user)):
+def invoke_sdk_kernel(req: InvokeRequest, user: Principal = Depends(get_current_user)):
     try:
         return invocation_service.invoke(
             user=user,
@@ -30,7 +30,11 @@ def invoke_sdk_kernel(req: InvokeRequest, user: str = Depends(get_current_user))
             mcp_server_ids=req.mcp_server_ids,
             skill_ids=req.skill_ids,
             memory_id=req.memory_id,
-            memory_actor_id=req.memory_actor_id,
+            # the actor ID selects whose memory the kernel retrieves — never
+            # pass it through verbatim (see resolve_memory_actor)
+            memory_actor_id=invocation_service.resolve_memory_actor(
+                user, req.memory_actor_id
+            ),
             memory_last_k_turns=req.memory_last_k_turns,
         )
     except (QuotaExceeded, SourceDisabled) as e:

--- a/backend/app/services/invocation_service.py
+++ b/backend/app/services/invocation_service.py
@@ -32,6 +32,35 @@ class IdentityRequired(Exception):
     path has no end-user token (internal caller, or non-OIDC auth mode)."""
 
 
+def resolve_memory_actor(user, requested: str) -> str:
+    """Map a request-supplied memory actor onto one the caller may address.
+
+    AgentCore Memory keys long-term records by actor (``/users/{actorId}``),
+    which makes the actor ID an authorization boundary, not a label: whoever
+    chooses it chooses whose records the kernel retrieves and injects into
+    the system prompt. Taking it from the request verbatim would let any
+    authenticated user read any other user's memory through the invoke path —
+    the same records the memory-browsing API restricts to admins.
+
+    A caller still has legitimate reasons to keep more than one memory line
+    (one per project, say), so a supplied value is namespaced under the
+    caller (``{caller}:{requested}``) rather than rejected. Admins keep
+    verbatim addressing, matching the browsing surface they already hold.
+
+    Applied at the API boundary (kernels/agents routes), not inside
+    :func:`invoke`: internal callers (channels, service entry) derive their
+    actor server-side from values the caller cannot forge — e.g.
+    ``chn-{channel_id}-{conversation_id}`` — and must reach :func:`invoke`
+    unmodified so an existing conversation's memory line stays stable.
+    """
+    caller = str(user)
+    if not requested or requested == caller:
+        return caller
+    if getattr(user, "is_admin", False):
+        return requested
+    return f"{caller}:{requested}"
+
+
 def forward_identity(mcp_servers: list[dict]) -> list[dict]:
     """Resolve ``{{user_token}}`` in attachment headers to the caller's token.
 

--- a/backend/app/services/workspace_credentials_service.py
+++ b/backend/app/services/workspace_credentials_service.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
 # Role chaining (task role → workspace-access role) caps sessions at 1h.
 CREDS_DURATION_S = 3600
 
+# Partition for the runtime_session_id → refresh-token lookup items.
+WS_TOKEN_PK = "WSTOKEN"
+
 
 def _session_policy(runtime_session_id: str) -> str:
     import json
@@ -101,14 +104,36 @@ class WorkspaceCredentialsService:
     # ------------------------------------------------ refresh-token flow
 
     def issue_refresh_token(self, user: str, session_id: str) -> str:
-        """Mint (or rotate) the per-session refresh token. Stored on the
-        session item; sent to the container only inside the warmup payload."""
+        """Mint (or rotate) the per-session refresh token.
+
+        Written twice: onto the session item (under the user's partition, as
+        before) and into a ``WSTOKEN`` lookup item keyed by the
+        ``runtime_session_id`` the container presents on refresh. The lookup
+        item is what lets :meth:`refresh` be a ``get_item`` instead of a
+        table scan — a filtered scan reads a single 1 MB page of *unfiltered*
+        data, and this table is shared (sessions, channels, ledger, audit),
+        so past 1 MB the matching session silently stops being found and
+        workspace sync dies after the first hour with no error anywhere.
+        """
         token = secrets.token_urlsafe(32)
-        self.table.update_item(
+        attrs = self.table.update_item(
             Key={"PK": f"USER#{user}", "SK": f"SESSION#{session_id}"},
             UpdateExpression="SET ws_refresh_token = :t",
             ExpressionAttributeValues={":t": token},
-        )
+            ReturnValues="ALL_NEW",
+        ).get("Attributes", {})
+        runtime_session_id = str(attrs.get("runtime_session_id", ""))
+        if runtime_session_id:
+            self.table.put_item(
+                Item={
+                    "PK": WS_TOKEN_PK,
+                    "SK": f"RSID#{runtime_session_id}",
+                    "ws_refresh_token": token,
+                    "runtime_session_id": runtime_session_id,
+                    "user": user,
+                    "session_id": session_id,
+                }
+            )
         return token
 
     def refresh(self, runtime_session_id: str, token: str) -> dict | None:
@@ -120,17 +145,50 @@ class WorkspaceCredentialsService:
         """
         if not runtime_session_id or not token:
             return None
-        resp = self.table.scan(
-            FilterExpression="runtime_session_id = :r",
-            ExpressionAttributeValues={":r": runtime_session_id},
-        )
-        items = resp.get("Items", [])
-        if len(items) != 1:
-            return None
-        expected = items[0].get("ws_refresh_token", "")
+        expected = self._lookup_token(runtime_session_id)
         if not expected or not hmac.compare_digest(expected, token):
             return None
         return self.mint(runtime_session_id)
+
+    def _lookup_token(self, runtime_session_id: str) -> str:
+        """The stored refresh token for a runtime session, or "".
+
+        Direct key read against the WSTOKEN partition. Sessions whose token
+        was issued before the lookup item existed fall back to a fully
+        paginated scan, so a workspace already in flight keeps refreshing
+        across the deploy of this change; the fallback goes cold once those
+        sessions' credentials expire (1 h) and connect() reissues.
+        """
+        item = self.table.get_item(
+            Key={"PK": WS_TOKEN_PK, "SK": f"RSID#{runtime_session_id}"}
+        ).get("Item")
+        if item:
+            return str(item.get("ws_refresh_token", ""))
+        return self._legacy_scan_token(runtime_session_id)
+
+    def _legacy_scan_token(self, runtime_session_id: str) -> str:
+        """Pre-migration fallback: walk every page. The original single-page
+        scan silently missed sessions once the table passed 1 MB, and treated
+        "several matches" like "none" — both still fail closed here."""
+        kwargs: dict = {
+            "FilterExpression": "runtime_session_id = :r",
+            "ExpressionAttributeValues": {":r": runtime_session_id},
+        }
+        found: list[dict] = []
+        while True:
+            resp = self.table.scan(**kwargs)
+            found.extend(i for i in resp.get("Items", []) if i.get("ws_refresh_token"))
+            if len(found) > 1:
+                logger.error(
+                    "ambiguous runtime_session_id %s — refusing to mint credentials",
+                    runtime_session_id,
+                )
+                return ""
+            start_key = resp.get("LastEvaluatedKey")
+            if not start_key:
+                break
+            kwargs["ExclusiveStartKey"] = start_key
+        return str(found[0].get("ws_refresh_token", "")) if len(found) == 1 else ""
 
 
 workspace_credentials_service = WorkspaceCredentialsService()

--- a/scripts/check_memory_actor_authz.py
+++ b/scripts/check_memory_actor_authz.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Authorization checks for the memory actor boundary.
+
+The actor ID selects whose AgentCore Memory records get retrieved and injected
+into the kernel system prompt, so it is an authorization boundary rather than
+a label. This script asserts a request-supplied value can never address
+another principal's memory line — and that the routes actually apply the
+mapping, since the function being correct is worthless if a call site passes
+the request value through verbatim (which is exactly the bug this guards
+against regressing).
+
+No third-party dependencies and no AWS calls, so it is safe in CI:
+``resolve_memory_actor`` is read straight out of the module source and
+executed in isolation, avoiding the FastAPI/boto3 import chain the package
+normally pulls in.
+
+Run: python3 scripts/check_memory_actor_authz.py
+"""
+
+import ast
+import os
+import re
+import sys
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "backend", "app")
+SRC = os.path.join(ROOT, "services", "invocation_service.py")
+FUNC = "resolve_memory_actor"
+
+
+def load_function():
+    """Exec just the target function so importing the service (boto3,
+    FastAPI) is not required."""
+    with open(SRC, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == FUNC:
+            module = ast.Module(body=[node], type_ignores=[])
+            namespace: dict = {}
+            exec(compile(module, SRC, "exec"), namespace)  # noqa: S102 — own source
+            return namespace[FUNC]
+    raise SystemExit(f"{FUNC} not found in {SRC} — did the fix get reverted?")
+
+
+resolve_memory_actor = load_function()
+
+
+class FakePrincipal(str):
+    """Stands in for app.dependencies.Principal (a str subclass + is_admin)."""
+
+    is_admin = False
+
+
+def _user(name, admin=False):
+    p = FakePrincipal(name)
+    p.is_admin = admin
+    return p
+
+
+FAILURES = []
+
+
+def check(label, actual, expected):
+    ok = actual == expected
+    if not ok:
+        FAILURES.append(f"{label}: expected {expected!r}, got {actual!r}")
+    print(f"  {'ok  ' if ok else 'FAIL'} {label}")
+
+
+alice = _user("alice")
+admin = _user("admin", admin=True)
+
+print("ordinary user:")
+# the case that matters: another principal's actor must not be addressable
+check("cannot address another user's actor", resolve_memory_actor(alice, "admin"), "alice:admin")
+check("empty request falls back to caller", resolve_memory_actor(alice, ""), "alice")
+check("own name stays unprefixed", resolve_memory_actor(alice, "alice"), "alice")
+check("extra memory lines stay under caller", resolve_memory_actor(alice, "proj-x"), "alice:proj-x")
+# a crafted value must not escape the caller namespace by re-prefixing
+check("cannot forge a nested actor", resolve_memory_actor(alice, "bob:proj"), "alice:bob:proj")
+
+print("administrator:")
+check("keeps verbatim addressing", resolve_memory_actor(admin, "alice"), "alice")
+check("empty request falls back to caller", resolve_memory_actor(admin, ""), "admin")
+
+# ---- the routes must run the request value through the mapping -------------
+# A raw `memory_actor_id=req.memory_actor_id` in a route file is the exact
+# regression this script exists to catch.
+print("call sites:")
+for route_file in ("api/kernels.py", "api/agents.py"):
+    path = os.path.join(ROOT, route_file)
+    with open(path, encoding="utf-8") as fh:
+        src = fh.read()
+    label = f"{route_file} maps the request actor"
+    if re.search(r"memory_actor_id\s*=\s*req\.memory_actor_id", src):
+        FAILURES.append(f"{label}: request value passed through verbatim")
+        print(f"  FAIL {label}")
+    elif f"{FUNC}(" in src:
+        print(f"  ok   {label}")
+    else:
+        FAILURES.append(f"{label}: no call to {FUNC} found")
+        print(f"  FAIL {label}")
+
+if FAILURES:
+    print(f"\n{len(FAILURES)} failure(s):")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("\nall checks passed")

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,6 +81,7 @@ module "portal" {
   log_bucket                = module.platform.log_bucket
   cf_log_destination_arn    = module.platform.cf_log_destination_arn
   backend_image_tag         = coalesce(var.backend_image_tag, var.image_tag)
+  backend_desired_count     = var.backend_desired_count
   interactive_runtime_arn   = module.runtime[0].interactive_runtime_arn
   sdk_runtime_arn           = module.runtime[0].sdk_runtime_arn
   mcp_tools_runtime_arn     = module.runtime[0].mcp_tools_runtime_arn

--- a/terraform/modules/portal/ecs.tf
+++ b/terraform/modules/portal/ecs.tf
@@ -461,8 +461,15 @@ resource "aws_ecs_service" "backend" {
   name            = "agent-platform-backend${var.name_suffix}"
   cluster         = aws_ecs_cluster.portal.id
   task_definition = aws_ecs_task_definition.backend.arn
-  desired_count   = 1
+  desired_count   = var.backend_desired_count
   launch_type     = "FARGATE"
+
+  # A task that fails its health checks otherwise leaves ECS retrying the
+  # broken revision indefinitely — roll back to the last working one instead.
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
 
   network_configuration {
     subnets          = var.private_subnet_ids

--- a/terraform/modules/portal/variables.tf
+++ b/terraform/modules/portal/variables.tf
@@ -50,6 +50,11 @@ variable "backend_image_tag" {
   type = string
 }
 
+variable "backend_desired_count" {
+  type    = number
+  default = 2
+}
+
 variable "interactive_runtime_arn" {
   type = string
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -152,6 +152,17 @@ variable "service_api_allowed_vpces" {
 #   phase 2: push images (scripts/build-and-push.sh)
 #   phase 3: terraform apply
 
+variable "backend_desired_count" {
+  description = "Backend ECS task count. 2 (one per AZ) keeps the control plane serving through deployments and single-task failures; 1 halves the backend Fargate cost for evaluation setups that can tolerate a brief outage on every deploy."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.backend_desired_count >= 1
+    error_message = "backend_desired_count must be at least 1."
+  }
+}
+
 variable "enable_runtime" {
   description = "Create the AgentCore runtimes (requires kernel images pushed)."
   type        = bool


### PR DESCRIPTION
Implements the fixes from #8 and #9 on this line (the PR branches and this history have diverged).

- **Availability (#8)**: deployment circuit breaker + rollback on the backend ECS service; `backend_desired_count` variable defaulting to 2 (one task per private subnet). Set 1 to halve the backend Fargate cost where a brief outage per deploy is acceptable.
- **Memory actor (#9)**: a request-supplied `memory_actor_id` is namespaced under the caller (`{caller}:{requested}`) at the API boundary; admins keep verbatim addressing; internal callers (channels) are untouched. `scripts/check_memory_actor_authz.py` guards the mapping and both call sites.
- **Workspace refresh (#9)**: the refresh token also lands in a `WSTOKEN` lookup item; `refresh()` becomes a direct `get_item` with a fully paginated scan fallback for in-flight sessions (ambiguity fails closed).

All verified against a live deployment: 2/2 tasks across AZs, rollout COMPLETED; a non-admin invoking with another user's actor lands in `alice:admin`; the lookup item is written on connect; a stored token mints scoped credentials, a wrong token gets 401.

Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)