### PR TITLE
Add an AWS CLI deployment path with a post-deployment verification suite

### DIFF
--- a/deploy-cli/.gitignore
+++ b/deploy-cli/.gitignore
@@ -1,0 +1,5 @@
+# Resource ids recorded by the deploy scripts. This is the closest thing this
+# path has to terraform state — and it contains the generated service-entry and
+# origin-verify secrets in plain text. Keep it out of version control; back it
+# up somewhere private instead (losing it orphans the stack).
+.state/

--- a/deploy-cli/lib/common.sh
+++ b/deploy-cli/lib/common.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Shared config + helpers for the CLI deployment.
+#
+# Terraform gets idempotence and dependency ordering for free from state and the
+# resource graph. Neither exists here, so every create is written as
+# "look it up, create only if absent" and every ordering constraint is an
+# explicit wait. That is the bulk of what this port is actually about.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------- config
+# Credentials come from the ambient environment: set AWS_PROFILE yourself, or
+# rely on an instance/SSO role. No default profile name is assumed here.
+export AWS_REGION="${AWS_REGION:-us-west-2}"
+export AWS_PAGER=""
+
+# Appended to every fixed resource name so this stack coexists with the
+# terraform one in the same account+region (the terraform port calls this
+# name_suffix and exists for the same reason).
+# Empty for production-style names (agent-platform, agent-platform-workspaces-...).
+# Set it to coexist with a CDK/Terraform deployment in the same account+region —
+# the same purpose as terraform's name_suffix variable.
+SUFFIX="${SUFFIX:-}"
+# AgentCore runtime names only allow [a-zA-Z0-9_], so a "-cli" suffix becomes
+# "_cli". An empty suffix must stay empty — prefixing unconditionally would name
+# the runtimes "claude_code_kernel_", which diverges from the CDK/Terraform names.
+if [ -n "$SUFFIX" ]; then
+  RUNTIME_SUFFIX="_$(echo "$SUFFIX" | tr -d -- '-')"
+else
+  RUNTIME_SUFFIX=""
+fi
+
+NAME="agent-platform${SUFFIX}"
+VPC_CIDR="${VPC_CIDR:-10.20.0.0/16}"   # distinct from the terraform stack's 10.0.0.0/16
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)"
+if [ -z "$ACCOUNT_ID" ] || [ "$ACCOUNT_ID" = "None" ]; then
+  echo "Cannot resolve the AWS account: credentials are missing or expired." >&2
+  echo "  Set AWS_PROFILE (or refresh your SSO/role session) and retry." >&2
+  echo "  Check with: aws sts get-caller-identity" >&2
+  return 1 2>/dev/null || exit 1
+fi
+REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+WORKSPACE_BUCKET="agent-platform-workspaces${SUFFIX}-${ACCOUNT_ID}-${AWS_REGION}"
+FRONTEND_BUCKET="agent-platform-frontend${SUFFIX}-${ACCOUNT_ID}-${AWS_REGION}"
+LOGS_BUCKET="agent-platform-logs${SUFFIX}-${ACCOUNT_ID}-${AWS_REGION}"
+TABLE="agent-platform${SUFFIX}"
+LLM_SECRET="agent-platform${SUFFIX}/llm-gateway-key"
+ENTRY_SECRET="agent-platform${SUFFIX}/service-entry"
+
+KERNEL_REPOS=(claude-code-kernel agent-sdk-kernel mcp-tools-kernel backend)
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+# Model ids the runtimes bake in (mirrors terraform.tfvars).
+ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-global.anthropic.claude-sonnet-4-5-20250929-v1:0}"
+ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-global.anthropic.claude-haiku-4-5-20251001-v1:0}"
+ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL:-global.anthropic.claude-opus-5}"
+
+# Where resource ids get recorded. This file is this port's substitute for
+# terraform state: without it a re-run cannot find what it already built, and
+# later phases have no way to reference earlier ones.
+STATE_DIR="${STATE_DIR:-$HOME/Desktop/code/agentcore-cli-deploy/.state}"
+mkdir -p "$STATE_DIR"
+STATE_FILE="$STATE_DIR/${NAME}.env"
+touch "$STATE_FILE"
+
+# ---------------------------------------------------------------- output
+log()  { printf '  %s\n' "$*"; }
+step() { printf '\n== %s\n' "$*"; }
+warn() { printf '  !! %s\n' "$*" >&2; }
+die()  { printf '  XX %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------- state
+# save KEY VALUE — record an id so re-runs and later phases can find it
+save() {
+  local k="$1" v="$2"
+  # An empty or "None" id means the describe/create above silently failed;
+  # recording it would make the next phase reference a nonexistent resource.
+  if [ -z "$v" ] || [ "$v" = "None" ] || [ "$v" = "null" ]; then
+    warn "refusing to save empty $k"
+    return 0
+  fi
+  grep -v "^export ${k}=" "$STATE_FILE" > "$STATE_FILE.tmp" 2>/dev/null || true
+  mv "$STATE_FILE.tmp" "$STATE_FILE"
+  printf 'export %s=%q\n' "$k" "$v" >> "$STATE_FILE"
+  export "$k=$v"
+}
+
+load() { set +u; . "$STATE_FILE"; set -u; }
+
+# ---------------------------------------------------------------- waiting
+# retry_until "description" attempts sleep_seconds command...
+# Terraform's providers wait on resource state internally; here every
+# eventually-consistent step needs its own poll or the next call 400s.
+retry_until() {
+  local desc="$1" tries="$2" gap="$3"; shift 3
+  local i
+  for i in $(seq 1 "$tries"); do
+    if "$@" >/dev/null 2>&1; then return 0; fi
+    sleep "$gap"
+  done
+  warn "timed out waiting for: $desc"
+  return 1
+}

--- a/deploy-cli/lib/common.sh
+++ b/deploy-cli/lib/common.sh
@@ -60,7 +60,7 @@ ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL:-global.anthropic.c
 # Where resource ids get recorded. This file is this port's substitute for
 # terraform state: without it a re-run cannot find what it already built, and
 # later phases have no way to reference earlier ones.
-STATE_DIR="${STATE_DIR:-$HOME/Desktop/code/agentcore-cli-deploy/.state}"
+STATE_DIR="${STATE_DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.state"}"
 mkdir -p "$STATE_DIR"
 STATE_FILE="$STATE_DIR/${NAME}.env"
 touch "$STATE_FILE"

--- a/deploy-cli/scripts/00-deploy-all.sh
+++ b/deploy-cli/scripts/00-deploy-all.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Run every phase in order. Each script is idempotent, so this is safe to re-run
+# and is the closest equivalent to `terraform apply` this port has.
+#
+# Ordering is NOT derived from anything — it is this list. Terraform builds a
+# dependency graph and parallelises what it can; here the order is hand-encoded
+# and everything is serial.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+echo "### phase 1/6  network"        ; bash "$HERE/10-network.sh"
+echo "### phase 2/6  platform"       ; bash "$HERE/20-platform.sh"
+echo
+echo "### images must exist in the -cli ECR repos before phase 3:"
+echo "###   AgentCore validates image access at runtime-create time."
+echo "###   Build/push them (arm64) then continue."
+echo
+echo "### phase 3/6  runtime"        ; bash "$HERE/30-runtime.sh"
+echo "### phase 4/6  portal base"    ; bash "$HERE/40-portal-base.sh"
+echo "### phase 5/6  portal app"     ; bash "$HERE/50-portal-app.sh"
+echo "### phase 6/6  cloudfront+ecs" ; bash "$HERE/60-cloudfront-ecs.sh"
+echo "### phase 6b   service entry"  ; bash "$HERE/70-service-entry.sh"
+
+. "$HERE/../lib/common.sh"; load
+echo
+echo "portal:      ${PORTAL_URL:-?}"
+echo "service api: ${SERVICE_API_URL:-?}"
+echo "state file:  $STATE_FILE"

--- a/deploy-cli/scripts/10-network.sh
+++ b/deploy-cli/scripts/10-network.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Phase 1 — network: VPC, 2 public /24 + 2 private /20, IGW, fixed-EIP NAT,
+# egress-only runtime SG. Mirrors terraform modules/network.
+. "$(dirname "$0")/../lib/common.sh"
+load
+
+step "network ($NAME, $VPC_CIDR)"
+
+# ---- VPC ----
+VPC_ID="$(aws ec2 describe-vpcs --filters "Name=tag:Name,Values=$NAME" \
+  --query 'Vpcs[0].VpcId' --output text 2>/dev/null || echo None)"
+if [ "$VPC_ID" = "None" ]; then
+  VPC_ID="$(aws ec2 create-vpc --cidr-block "$VPC_CIDR" \
+    --tag-specifications "ResourceType=vpc,Tags=[{Key=Name,Value=$NAME}]" \
+    --query 'Vpc.VpcId' --output text)"
+  # Terraform sets both on the resource; over the API they are two more calls,
+  # and the runtimes need DNS names to resolve the gateway/S3 endpoints.
+  aws ec2 modify-vpc-attribute --vpc-id "$VPC_ID" --enable-dns-support
+  aws ec2 modify-vpc-attribute --vpc-id "$VPC_ID" --enable-dns-hostnames
+  log "created vpc $VPC_ID"
+else
+  log "vpc exists $VPC_ID"
+fi
+save VPC_ID "$VPC_ID"
+
+# ---- AZs: first two, same as terraform's slice(names, 0, 2) ----
+# NB: no mapfile here — macOS ships bash 3.2, where it does not exist. Anything
+# in this port that assumes bash 4 breaks on the most likely operator laptop.
+AZ_LIST="$(aws ec2 describe-availability-zones --filters Name=state,Values=available \
+  --query 'AvailabilityZones[].ZoneName' --output text | tr '\t' '\n' | sort | head -2)"
+AZ0="$(echo "$AZ_LIST" | sed -n 1p)"
+AZ1="$(echo "$AZ_LIST" | sed -n 2p)"
+[ -n "$AZ0" ] && [ -n "$AZ1" ] || die "could not resolve two availability zones"
+log "azs: $AZ0 $AZ1"
+
+# Mirror terraform's cidrsubnet() on a /16:
+#   cidrsubnet(vpc, 8, i)   -> a.b.i.0/24        (public)
+#   cidrsubnet(vpc, 4, i+1) -> a.b.(16*(i+1)).0/20  (private)
+# The /20 offset lands in the THIRD octet. Bumping the second (10.20 -> 10.36)
+# leaves the VPC range entirely and CreateSubnet rejects it as invalid.
+BASE="${VPC_CIDR%%/*}"; O1="${BASE%%.*}"; REST="${BASE#*.}"; O2="${REST%%.*}"
+
+# NB: these *_ensure helpers return an id on stdout, so every progress message
+# inside them must go to stderr. A single `log` on stdout gets captured by the
+# caller's $( ) and produces ids like "created subnet ...\nsubnet-abc" — which
+# then fail downstream as "malformed". Terraform has no equivalent trap.
+subnet_ensure() {  # name az cidr public
+  local sname="$1" az="$2" cidr="$3" public="$4" sid
+  sid="$(aws ec2 describe-subnets --filters "Name=tag:Name,Values=$sname" "Name=vpc-id,Values=$VPC_ID" \
+        --query 'Subnets[0].SubnetId' --output text 2>/dev/null || echo None)"
+  if [ "$sid" = "None" ]; then
+    sid="$(aws ec2 create-subnet --vpc-id "$VPC_ID" --cidr-block "$cidr" --availability-zone "$az" \
+      --tag-specifications "ResourceType=subnet,Tags=[{Key=Name,Value=$sname}]" \
+      --query 'Subnet.SubnetId' --output text)"
+    if [ "$public" = "yes" ]; then
+      aws ec2 modify-subnet-attribute --subnet-id "$sid" --map-public-ip-on-launch >/dev/null
+    fi
+    log "created subnet $sname $cidr -> $sid" >&2
+  else
+    log "subnet exists $sname -> $sid" >&2
+  fi
+  echo "$sid"
+}
+
+PUB0="$(subnet_ensure "$NAME-public-0" "$AZ0" "${O1}.${O2}.0.0/24" yes)"
+PUB1="$(subnet_ensure "$NAME-public-1" "$AZ1" "${O1}.${O2}.1.0/24" yes)"
+PRIV0="$(subnet_ensure "$NAME-runtime-0" "$AZ0" "${O1}.${O2}.16.0/20" no)"
+PRIV1="$(subnet_ensure "$NAME-runtime-1" "$AZ1" "${O1}.${O2}.32.0/20" no)"
+save PUBLIC_SUBNETS "$PUB0,$PUB1"
+save PRIVATE_SUBNETS "$PRIV0,$PRIV1"
+
+# ---- IGW ----
+IGW_ID="$(aws ec2 describe-internet-gateways --filters "Name=tag:Name,Values=$NAME" \
+  --query 'InternetGateways[0].InternetGatewayId' --output text 2>/dev/null || echo None)"
+if [ "$IGW_ID" = "None" ]; then
+  IGW_ID="$(aws ec2 create-internet-gateway \
+    --tag-specifications "ResourceType=internet-gateway,Tags=[{Key=Name,Value=$NAME}]" \
+    --query 'InternetGateway.InternetGatewayId' --output text)"
+  aws ec2 attach-internet-gateway --internet-gateway-id "$IGW_ID" --vpc-id "$VPC_ID"
+  log "created+attached igw $IGW_ID"
+else
+  log "igw exists $IGW_ID"
+fi
+save IGW_ID "$IGW_ID"
+
+# ---- EIP + NAT ----
+EIP_ALLOC="$(aws ec2 describe-addresses --filters "Name=tag:Name,Values=$NAME-nat" \
+  --query 'Addresses[0].AllocationId' --output text 2>/dev/null || echo None)"
+if [ "$EIP_ALLOC" = "None" ]; then
+  EIP_ALLOC="$(aws ec2 allocate-address --domain vpc \
+    --tag-specifications "ResourceType=elastic-ip,Tags=[{Key=Name,Value=$NAME-nat}]" \
+    --query 'AllocationId' --output text)"
+  log "allocated eip $EIP_ALLOC"
+fi
+save EIP_ALLOC "$EIP_ALLOC"
+NAT_IP="$(aws ec2 describe-addresses --allocation-ids "$EIP_ALLOC" --query 'Addresses[0].PublicIp' --output text)"
+save NAT_EIP "$NAT_IP"
+
+NAT_ID="$(aws ec2 describe-nat-gateways --filter "Name=tag:Name,Values=$NAME" "Name=state,Values=available,pending" \
+  --query 'NatGateways[0].NatGatewayId' --output text 2>/dev/null || echo None)"
+if [ "$NAT_ID" = "None" ]; then
+  NAT_ID="$(aws ec2 create-nat-gateway --subnet-id "$PUB0" --allocation-id "$EIP_ALLOC" \
+    --tag-specifications "ResourceType=natgateway,Tags=[{Key=Name,Value=$NAME}]" \
+    --query 'NatGateway.NatGatewayId' --output text)"
+  log "creating nat $NAT_ID (this takes ~1-2 min)"
+fi
+save NAT_ID "$NAT_ID"
+# A route to a NAT that is still pending is rejected, so this wait is load-bearing.
+log "waiting for nat to become available…"
+aws ec2 wait nat-gateway-available --nat-gateway-ids "$NAT_ID"
+log "nat available, eip $NAT_IP"
+
+# ---- route tables ----
+rt_ensure() {  # name
+  local rname="$1" rid
+  rid="$(aws ec2 describe-route-tables --filters "Name=tag:Name,Values=$rname" "Name=vpc-id,Values=$VPC_ID" \
+        --query 'RouteTables[0].RouteTableId' --output text 2>/dev/null || echo None)"
+  if [ "$rid" = "None" ]; then
+    rid="$(aws ec2 create-route-table --vpc-id "$VPC_ID" \
+      --tag-specifications "ResourceType=route-table,Tags=[{Key=Name,Value=$rname}]" \
+      --query 'RouteTable.RouteTableId' --output text)"
+    log "created route table $rname -> $rid" >&2
+  fi
+  echo "$rid"
+}
+RT_PUB="$(rt_ensure "$NAME-public")"
+RT_PRIV="$(rt_ensure "$NAME-private")"
+save RT_PUB "$RT_PUB"; save RT_PRIV "$RT_PRIV"
+
+# create-route is not idempotent — it errors if the route exists, so tolerate it
+aws ec2 create-route --route-table-id "$RT_PUB" --destination-cidr-block 0.0.0.0/0 \
+  --gateway-id "$IGW_ID" >/dev/null 2>&1 || log "public default route already present"
+aws ec2 create-route --route-table-id "$RT_PRIV" --destination-cidr-block 0.0.0.0/0 \
+  --nat-gateway-id "$NAT_ID" >/dev/null 2>&1 || log "private default route already present"
+
+assoc() {  # rtb subnet
+  aws ec2 associate-route-table --route-table-id "$1" --subnet-id "$2" >/dev/null 2>&1 \
+    || log "association exists for $2"
+}
+assoc "$RT_PUB" "$PUB0"; assoc "$RT_PUB" "$PUB1"
+assoc "$RT_PRIV" "$PRIV0"; assoc "$RT_PRIV" "$PRIV1"
+
+# ---- runtime SG (egress only; AgentCore reaches runtimes via its data plane) ----
+RUNTIME_SG="$(aws ec2 describe-security-groups \
+  --filters "Name=group-name,Values=$NAME-runtime-egress" "Name=vpc-id,Values=$VPC_ID" \
+  --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo None)"
+if [ "$RUNTIME_SG" = "None" ]; then
+  RUNTIME_SG="$(aws ec2 create-security-group --group-name "$NAME-runtime-egress" \
+    --description "Egress-only SG for AgentCore runtime ENIs" --vpc-id "$VPC_ID" \
+    --query GroupId --output text)"
+  log "created runtime sg $RUNTIME_SG"
+fi
+save RUNTIME_SG "$RUNTIME_SG"
+
+log "network done: vpc=$VPC_ID nat_eip=$NAT_IP"

--- a/deploy-cli/scripts/20-platform.sh
+++ b/deploy-cli/scripts/20-platform.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Phase 2 — platform: workspace bucket, logs bucket, DynamoDB, ECR repos,
+# LLM-gateway secret. Mirrors terraform modules/platform (incl. the hardening
+# from upstream 9e17d98: PITR, versioning, scan-on-push, access-log bucket).
+. "$(dirname "$0")/../lib/common.sh"
+load
+
+step "platform ($NAME)"
+
+# ------------------------------------------------------------------ buckets
+bucket_ensure() {  # name
+  local b="$1"
+  if aws s3api head-bucket --bucket "$b" >/dev/null 2>&1; then
+    log "bucket exists $b" >&2; return 0
+  fi
+  # us-east-1 must NOT be given a LocationConstraint; every other region must.
+  if [ "$AWS_REGION" = "us-east-1" ]; then
+    aws s3api create-bucket --bucket "$b" >/dev/null
+  else
+    aws s3api create-bucket --bucket "$b" \
+      --create-bucket-configuration "LocationConstraint=$AWS_REGION" >/dev/null
+  fi
+  log "created bucket $b" >&2
+}
+
+harden_bucket() {  # name
+  local b="$1"
+  aws s3api put-public-access-block --bucket "$b" --public-access-block-configuration \
+    'BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true' >/dev/null
+  aws s3api put-bucket-encryption --bucket "$b" --server-side-encryption-configuration \
+    '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' >/dev/null
+}
+
+bucket_ensure "$WORKSPACE_BUCKET"
+harden_bucket "$WORKSPACE_BUCKET"
+aws s3api put-bucket-versioning --bucket "$WORKSPACE_BUCKET" \
+  --versioning-configuration Status=Enabled >/dev/null
+log "workspace bucket ready (versioned, encrypted, private)"
+
+# TLS-only policy on the workspace bucket
+cat > /tmp/ws-policy.json <<JSON
+{"Version":"2012-10-17","Statement":[{
+  "Sid":"EnforceTLS","Effect":"Deny","Principal":{"AWS":"*"},"Action":"s3:*",
+  "Resource":["arn:aws:s3:::$WORKSPACE_BUCKET","arn:aws:s3:::$WORKSPACE_BUCKET/*"],
+  "Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}
+JSON
+aws s3api put-bucket-policy --bucket "$WORKSPACE_BUCKET" --policy file:///tmp/ws-policy.json
+save WORKSPACE_BUCKET "$WORKSPACE_BUCKET"
+
+# ---- logs bucket (ALB access logs + CloudFront vended logs) ----
+bucket_ensure "$LOGS_BUCKET"
+harden_bucket "$LOGS_BUCKET"
+# ALB log delivery writes with an ACL, so the bucket cannot be BucketOwnerEnforced
+aws s3api put-bucket-ownership-controls --bucket "$LOGS_BUCKET" \
+  --ownership-controls 'Rules=[{ObjectOwnership=BucketOwnerPreferred}]' >/dev/null
+aws s3api put-bucket-lifecycle-configuration --bucket "$LOGS_BUCKET" \
+  --lifecycle-configuration '{"Rules":[{"ID":"expire","Status":"Enabled","Filter":{},"Expiration":{"Days":90}}]}' >/dev/null
+
+# NB: the ALB statements use the logdelivery service principal (current model)
+# rather than the per-region ELB account id, matching what upstream terraform does.
+cat > /tmp/logs-policy.json <<JSON
+{"Version":"2012-10-17","Statement":[
+ {"Sid":"AlbLogDelivery","Effect":"Allow",
+  "Principal":{"Service":"logdelivery.elasticloadbalancing.amazonaws.com"},
+  "Action":"s3:PutObject","Resource":"arn:aws:s3:::$LOGS_BUCKET/alb/*",
+  "Condition":{"StringEquals":{"aws:SourceAccount":"$ACCOUNT_ID"}}},
+ {"Sid":"AlbLogDeliveryAcl","Effect":"Allow",
+  "Principal":{"Service":"logdelivery.elasticloadbalancing.amazonaws.com"},
+  "Action":"s3:GetBucketAcl","Resource":"arn:aws:s3:::$LOGS_BUCKET"},
+ {"Sid":"CloudFrontVendedLogsWrite","Effect":"Allow",
+  "Principal":{"Service":"delivery.logs.amazonaws.com"},
+  "Action":"s3:PutObject","Resource":"arn:aws:s3:::$LOGS_BUCKET/*",
+  "Condition":{"StringEquals":{"s3:x-amz-acl":"bucket-owner-full-control","aws:SourceAccount":"$ACCOUNT_ID"}}},
+ {"Sid":"CloudFrontVendedLogsAclCheck","Effect":"Allow",
+  "Principal":{"Service":"delivery.logs.amazonaws.com"},
+  "Action":["s3:GetBucketAcl","s3:ListBucket"],"Resource":"arn:aws:s3:::$LOGS_BUCKET",
+  "Condition":{"StringEquals":{"aws:SourceAccount":"$ACCOUNT_ID"}}},
+ {"Sid":"EnforceTLS","Effect":"Deny","Principal":{"AWS":"*"},"Action":"s3:*",
+  "Resource":["arn:aws:s3:::$LOGS_BUCKET","arn:aws:s3:::$LOGS_BUCKET/*"],
+  "Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}
+JSON
+aws s3api put-bucket-policy --bucket "$LOGS_BUCKET" --policy file:///tmp/logs-policy.json
+save LOGS_BUCKET "$LOGS_BUCKET"
+log "logs bucket ready (90d expiry, delivery principals allowed)"
+
+# ---- frontend bucket (CloudFront OAC reads it; policy set in the portal phase,
+# which is where the distribution ARN it must be pinned to first exists) ----
+bucket_ensure "$FRONTEND_BUCKET"
+harden_bucket "$FRONTEND_BUCKET"
+save FRONTEND_BUCKET "$FRONTEND_BUCKET"
+
+# ------------------------------------------------------------------ dynamodb
+if aws dynamodb describe-table --table-name "$TABLE" >/dev/null 2>&1; then
+  log "table exists $TABLE"
+else
+  aws dynamodb create-table --table-name "$TABLE" \
+    --attribute-definitions AttributeName=PK,AttributeType=S AttributeName=SK,AttributeType=S \
+    --key-schema AttributeName=PK,KeyType=HASH AttributeName=SK,KeyType=RANGE \
+    --billing-mode PAY_PER_REQUEST \
+    --sse-specification Enabled=true >/dev/null
+  log "creating table $TABLE"
+  aws dynamodb wait table-exists --table-name "$TABLE"
+fi
+# PITR can only be set once the table is ACTIVE, and the call is not idempotent
+# in the sense of being safe to blind-fire: it errors if already enabled.
+aws dynamodb update-continuous-backups --table-name "$TABLE" \
+  --point-in-time-recovery-specification PointInTimeRecoveryEnabled=true >/dev/null 2>&1 \
+  || log "PITR already enabled"
+save TABLE "$TABLE"
+log "table ready (PITR + SSE)"
+
+# ------------------------------------------------------------------ ecr
+for r in "${KERNEL_REPOS[@]}"; do
+  repo="agent-platform${SUFFIX}/${r}"
+  if aws ecr describe-repositories --repository-names "$repo" >/dev/null 2>&1; then
+    log "ecr exists $repo"
+  else
+    aws ecr create-repository --repository-name "$repo" \
+      --image-scanning-configuration scanOnPush=true >/dev/null
+    log "created ecr $repo (scan-on-push)"
+  fi
+done
+save ECR_PREFIX "agent-platform${SUFFIX}"
+
+# ------------------------------------------------------------------ secrets
+secret_ensure() {  # name json-value
+  local n="$1" v="$2"
+  if aws secretsmanager describe-secret --secret-id "$n" >/dev/null 2>&1; then
+    log "secret exists $n" >&2
+  else
+    aws secretsmanager create-secret --name "$n" --secret-string "$v" >/dev/null
+    log "created secret $n" >&2
+  fi
+}
+# Placeholder only — the real key is set out of band, same as terraform's
+# ignore_changes on the version.
+secret_ensure "$LLM_SECRET" '{"api_key":"REPLACE_ME"}'
+save LLM_SECRET "$LLM_SECRET"
+
+log "platform done"

--- a/deploy-cli/scripts/30-runtime.sh
+++ b/deploy-cli/scripts/30-runtime.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Phase 3 — IAM execution roles (one per kernel) + workspace-access role,
+# then the three AgentCore runtimes. Mirrors terraform modules/runtime.
+. "$(dirname "$0")/../lib/common.sh"
+load
+: "${VPC_ID:?run 10-network.sh first}"
+: "${WORKSPACE_BUCKET:?run 20-platform.sh first}"
+
+step "runtime roles + AgentCore runtimes ($NAME)"
+
+WS_ARN="arn:aws:s3:::$WORKSPACE_BUCKET"
+LLM_ARN="$(aws secretsmanager describe-secret --secret-id "$LLM_SECRET" --query ARN --output text)"
+REPO_ARNS="$(for r in "${KERNEL_REPOS[@]}"; do
+  aws ecr describe-repositories --repository-names "agent-platform${SUFFIX}/$r" \
+    --query 'repositories[0].repositoryArn' --output text; done | paste -sd',' - \
+  | sed 's/[^,]*/"&"/g')"
+
+TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"bedrock-agentcore.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+role_ensure() {  # name trust-json description
+  local rn="$1" trust="$2" desc="$3" arn
+  arn="$(aws iam get-role --role-name "$rn" --query 'Role.Arn' --output text 2>/dev/null || echo None)"
+  if [ "$arn" = "None" ]; then
+    arn="$(aws iam create-role --role-name "$rn" --assume-role-policy-document "$trust" \
+      --description "$desc" --query 'Role.Arn' --output text)"
+    log "created role $rn" >&2
+  else
+    log "role exists $rn" >&2
+  fi
+  echo "$arn"
+}
+
+# ---------------------------------------------------------------- policies
+base_stmts() { cat <<JSON
+{"Sid":"EcrPull","Effect":"Allow","Action":["ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Resource":[$REPO_ARNS]}
+{"Sid":"EcrAuth","Effect":"Allow","Action":"ecr:GetAuthorizationToken","Resource":"*"}
+{"Sid":"Logs","Effect":"Allow","Action":["logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents","logs:DescribeLogGroups","logs:DescribeLogStreams"],"Resource":"arn:aws:logs:$AWS_REGION:$ACCOUNT_ID:log-group:/aws/bedrock-agentcore/*"}
+JSON
+}
+
+agent_stmts() { cat <<JSON
+{"Sid":"Skills","Effect":"Allow","Action":"s3:GetObject","Resource":"$WS_ARN/skills/*"}
+{"Sid":"SkillsList","Effect":"Allow","Action":"s3:ListBucket","Resource":"$WS_ARN","Condition":{"StringLike":{"s3:prefix":["skills/*","skills/"]}}}
+{"Sid":"LlmGatewaySecret","Effect":"Allow","Action":["secretsmanager:GetSecretValue","secretsmanager:DescribeSecret"],"Resource":"$LLM_ARN"}
+{"Sid":"BedrockInvoke","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource":"*"}
+{"Sid":"InvokeMcpRuntimes","Effect":"Allow","Action":"bedrock-agentcore:InvokeAgentRuntime","Resource":["arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:runtime/mcp_tools_kernel*","arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:runtime/mcp_tools_kernel*/runtime-endpoint/*"]}
+{"Sid":"InvokeGateways","Effect":"Allow","Action":"bedrock-agentcore:InvokeGateway","Resource":["arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:gateway/*","arn:aws:bedrock-agentcore:us-east-1:$ACCOUNT_ID:gateway/*"]}
+{"Sid":"BuiltinTools","Effect":"Allow","Action":["bedrock-agentcore:StartCodeInterpreterSession","bedrock-agentcore:InvokeCodeInterpreter","bedrock-agentcore:StopCodeInterpreterSession","bedrock-agentcore:GetCodeInterpreterSession","bedrock-agentcore:StartBrowserSession","bedrock-agentcore:StopBrowserSession","bedrock-agentcore:GetBrowserSession","bedrock-agentcore:UpdateBrowserStream","bedrock-agentcore:ConnectBrowserAutomationStream","bedrock-agentcore:ConnectBrowserLiveViewStream"],"Resource":["arn:aws:bedrock-agentcore:$AWS_REGION:aws:code-interpreter/aws.codeinterpreter.v1","arn:aws:bedrock-agentcore:$AWS_REGION:aws:browser/aws.browser.v1","arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:code-interpreter/*","arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:browser/*"]}
+JSON
+}
+
+sdk_stmts() { cat <<JSON
+{"Sid":"AsyncArtifacts","Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:AbortMultipartUpload"],"Resource":["$WS_ARN/feeds/*","$WS_ARN/topic-selection/*"]}
+{"Sid":"AsyncArtifactsList","Effect":"Allow","Action":"s3:ListBucket","Resource":"$WS_ARN","Condition":{"StringLike":{"s3:prefix":["feeds/*","feeds/","topic-selection/*","topic-selection/"]}}}
+{"Sid":"McpSecrets","Effect":"Allow","Action":"secretsmanager:GetSecretValue","Resource":"arn:aws:secretsmanager:$AWS_REGION:$ACCOUNT_ID:secret:agent-platform*/remote-mcp-key*"}
+{"Sid":"MemoryData","Effect":"Allow","Action":["bedrock-agentcore:CreateEvent","bedrock-agentcore:GetEvent","bedrock-agentcore:ListEvents","bedrock-agentcore:ListActors","bedrock-agentcore:ListSessions","bedrock-agentcore:GetMemoryRecord","bedrock-agentcore:ListMemoryRecords","bedrock-agentcore:RetrieveMemoryRecords"],"Resource":"arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:memory/*"}
+JSON
+}
+
+# Assemble the document in python rather than by string-pasting in shell: the
+# statement helpers emit one JSON object per line, and joining them by hand left
+# newlines where commas belonged (a malformed policy that IAM would have taken
+# happily as far as syntax goes, but which the validator below catches first).
+put_policy() {  # role-name  newline-separated-statements
+  local rn="$1" stmts="$2"
+  printf '%s' "$stmts" | python3 -c '
+import json, sys
+objs = [json.loads(l) for l in sys.stdin.read().splitlines() if l.strip()]
+json.dump({"Version": "2012-10-17", "Statement": objs}, open("/tmp/pol.json", "w"))
+print(len(objs))' > /tmp/pol.count || die "policy for $rn is not valid JSON"
+  aws iam put-role-policy --role-name "$rn" --policy-name kernel --policy-document file:///tmp/pol.json
+  log "policy attached: $rn ($(cat /tmp/pol.count) statements)"
+}
+
+R_INT="agent-platform-interactive-role${SUFFIX}"
+R_SDK="agent-platform-sdk-role${SUFFIX}"
+R_MCP="agent-platform-mcp-tools-role${SUFFIX}"
+R_WS="agent-platform-workspace-access${SUFFIX}"
+
+INT_ARN="$(role_ensure "$R_INT" "$TRUST" "claude-code-kernel: skills read; workspace sync uses backend-minted per-session credentials")"
+SDK_ARN="$(role_ensure "$R_SDK" "$TRUST" "agent-sdk-kernel: skills read + async artifact prefixes")"
+MCP_ARN="$(role_ensure "$R_MCP" "$TRUST" "mcp-tools-kernel: demo MCP server, no S3 access")"
+save INTERACTIVE_ROLE_ARN "$INT_ARN"; save SDK_ROLE_ARN "$SDK_ARN"; save MCP_ROLE_ARN "$MCP_ARN"
+
+put_policy "$R_INT" "$(base_stmts; agent_stmts)"
+put_policy "$R_SDK" "$(base_stmts; agent_stmts; sdk_stmts)"
+put_policy "$R_MCP" "$(base_stmts)"
+
+# ---- workspace-access role: assumed by the backend per session ----
+WS_TRUST="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::$ACCOUNT_ID:root\"},\"Action\":\"sts:AssumeRole\"}]}"
+WS_ROLE_ARN="$(role_ensure "$R_WS" "$WS_TRUST" "Assumed per session by the backend; session policy narrows to that session prefix")"
+cat > /tmp/ws-role-pol.json <<JSON
+{"Version":"2012-10-17","Statement":[
+ {"Sid":"Workspaces","Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:AbortMultipartUpload"],"Resource":"$WS_ARN/workspaces/*"},
+ {"Sid":"WorkspacesList","Effect":"Allow","Action":"s3:ListBucket","Resource":"$WS_ARN","Condition":{"StringLike":{"s3:prefix":["workspaces/*","workspaces/"]}}}]}
+JSON
+aws iam put-role-policy --role-name "$R_WS" --policy-name workspaces --policy-document file:///tmp/ws-role-pol.json
+save WORKSPACE_ROLE_ARN "$WS_ROLE_ARN"
+log "workspace-access role ready"
+
+# ---------------------------------------------------------------- runtimes
+# Env shared by both agent kernels (mirrors locals.common_env with use_bedrock=1).
+common_env_json() { cat <<JSON
+{"AWS_REGION":"$AWS_REGION","LLM_GATEWAY_SECRET_NAME":"$LLM_SECRET","CLAUDE_CODE_USE_BEDROCK":"1","ANTHROPIC_MODEL":"$ANTHROPIC_MODEL","ANTHROPIC_SMALL_FAST_MODEL":"$ANTHROPIC_SMALL_FAST_MODEL","ANTHROPIC_DEFAULT_OPUS_MODEL":"$ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL":"$ANTHROPIC_MODEL","ANTHROPIC_DEFAULT_HAIKU_MODEL":"$ANTHROPIC_SMALL_FAST_MODEL"}
+JSON
+}
+
+PRIV0="${PRIVATE_SUBNETS%%,*}"; PRIV1="${PRIVATE_SUBNETS##*,}"
+NET_CFG="{\"networkMode\":\"VPC\",\"networkModeConfig\":{\"securityGroups\":[\"$RUNTIME_SG\"],\"subnets\":[\"$PRIV0\",\"$PRIV1\"]}}"
+
+runtime_ensure() {  # logical-name image-repo role-arn protocol env-json
+  local lname="$1" repo="$2" role="$3" proto="$4" env="$5"
+  local rt_name="${lname}${RUNTIME_SUFFIX}" arn
+  arn="$(aws bedrock-agentcore-control list-agent-runtimes \
+        --query "agentRuntimes[?agentRuntimeName=='$rt_name'].agentRuntimeArn | [0]" --output text 2>/dev/null || echo None)"
+  if [ "$arn" != "None" ] && [ -n "$arn" ]; then
+    log "runtime exists $rt_name" >&2; echo "$arn"; return 0
+  fi
+  local uri="${REGISTRY}/agent-platform${SUFFIX}/${repo}:${IMAGE_TAG}"
+  arn="$(aws bedrock-agentcore-control create-agent-runtime \
+    --agent-runtime-name "$rt_name" \
+    --description "$lname (CLI-deployed)" \
+    --role-arn "$role" \
+    --agent-runtime-artifact "{\"containerConfiguration\":{\"containerUri\":\"$uri\"}}" \
+    --network-configuration "$NET_CFG" \
+    --protocol-configuration "{\"serverProtocol\":\"$proto\"}" \
+    --environment-variables "$env" \
+    --query 'agentRuntimeArn' --output text)"
+  log "created runtime $rt_name" >&2
+  echo "$arn"
+}
+
+# AgentCore validates image pull with the execution role at CREATE time, so the
+# inline policy must have propagated first. Terraform expresses this with
+# depends_on; here it is a real wait — IAM is eventually consistent and a create
+# fired immediately after put-role-policy fails with an image-access error that
+# looks like a bad image URI.
+log "waiting 20s for IAM policy propagation before creating runtimes"
+sleep 20
+
+# The interactive kernel additionally needs the workspace bucket it syncs to.
+INT_ENV="$(common_env_json | python3 -c '
+import json,sys,os
+env = json.load(sys.stdin)
+env["WORKSPACE_S3_BUCKET"] = os.environ["WORKSPACE_BUCKET"]
+env["WORKSPACE_S3_PREFIX"] = "workspaces"
+print(json.dumps(env))')"
+INT_RT="$(runtime_ensure claude_code_kernel claude-code-kernel "$INT_ARN" HTTP "$INT_ENV")"
+SDK_RT="$(runtime_ensure agent_sdk_kernel agent-sdk-kernel "$SDK_ARN" HTTP "$(common_env_json)")"
+MCP_RT="$(runtime_ensure mcp_tools_kernel mcp-tools-kernel "$MCP_ARN" MCP '{"AWS_REGION":"'"$AWS_REGION"'"}')"
+
+save INTERACTIVE_RUNTIME_ARN "$INT_RT"
+save SDK_RUNTIME_ARN "$SDK_RT"
+save MCP_TOOLS_RUNTIME_ARN "$MCP_RT"
+
+log "waiting for runtimes to become READY…"
+for rt in claude_code_kernel agent_sdk_kernel mcp_tools_kernel; do
+  n="${rt}${RUNTIME_SUFFIX}"
+  for i in $(seq 1 40); do
+    st="$(aws bedrock-agentcore-control list-agent-runtimes \
+      --query "agentRuntimes[?agentRuntimeName=='$n'].status | [0]" --output text 2>/dev/null)"
+    [ "$st" = "READY" ] && { log "  $n READY"; break; }
+    case "$st" in
+      CREATE_FAILED|UPDATE_FAILED|DELETING) warn "  $n -> $st"; break ;;
+    esac
+    sleep 15
+  done
+done
+
+log "runtime phase done"

--- a/deploy-cli/scripts/40-portal-base.sh
+++ b/deploy-cli/scripts/40-portal-base.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Phase 4a — portal foundations: Cognito, ALB (+origin-verify secret), target
+# groups, ECS cluster, task/exec roles, scheduler group + DLQ + runner Lambda.
+# Mirrors terraform modules/portal parts 1-3.
+. "$(dirname "$0")/../lib/common.sh"
+load
+: "${VPC_ID:?run 10-network.sh}"; : "${SDK_RUNTIME_ARN:?run 30-runtime.sh}"
+
+step "portal base ($NAME)"
+PUB0="${PUBLIC_SUBNETS%%,*}"; PUB1="${PUBLIC_SUBNETS##*,}"
+PRIV0="${PRIVATE_SUBNETS%%,*}"; PRIV1="${PRIVATE_SUBNETS##*,}"
+
+# ------------------------------------------------------------------ cognito
+POOL_ID="$(aws cognito-idp list-user-pools --max-results 60 \
+  --query "UserPools[?Name=='$NAME'].Id | [0]" --output text 2>/dev/null || echo None)"
+if [ "$POOL_ID" = "None" ] || [ -z "$POOL_ID" ]; then
+  POOL_ID="$(aws cognito-idp create-user-pool --pool-name "$NAME" \
+    --admin-create-user-config 'AllowAdminCreateUserOnly=true' \
+    --alias-attributes email \
+    --auto-verified-attributes email \
+    --policies 'PasswordPolicy={MinimumLength=12,RequireUppercase=false,RequireLowercase=false,RequireNumbers=false,RequireSymbols=false}' \
+    --query 'UserPool.Id' --output text)"
+  log "created user pool $POOL_ID"
+else
+  log "user pool exists $POOL_ID"
+fi
+save POOL_ID "$POOL_ID"
+
+CLIENT_ID="$(aws cognito-idp list-user-pool-clients --user-pool-id "$POOL_ID" --max-results 60 \
+  --query "UserPoolClients[?ClientName=='PortalClient'].ClientId | [0]" --output text 2>/dev/null || echo None)"
+if [ "$CLIENT_ID" = "None" ] || [ -z "$CLIENT_ID" ]; then
+  CLIENT_ID="$(aws cognito-idp create-user-pool-client --user-pool-id "$POOL_ID" \
+    --client-name PortalClient \
+    --explicit-auth-flows ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+    --id-token-validity 12 --access-token-validity 12 \
+    --token-validity-units 'IdToken=hours,AccessToken=hours,RefreshToken=days' \
+    --query 'UserPoolClient.ClientId' --output text)"
+  log "created pool client $CLIENT_ID"
+else
+  log "pool client exists $CLIENT_ID"
+fi
+save CLIENT_ID "$CLIENT_ID"
+
+aws cognito-idp create-group --user-pool-id "$POOL_ID" --group-name platform-admin \
+  --description "Agent Platform administrators" >/dev/null 2>&1 \
+  || log "group platform-admin already exists"
+
+# ------------------------------------------------------ origin-verify secret
+# Same role as terraform's random_password.origin_verify: proves to the ALB that
+# a request arrived through THIS distribution (the SG prefix list admits every
+# CloudFront distribution, not just ours).
+if [ -z "${ORIGIN_VERIFY:-}" ]; then
+  ORIGIN_VERIFY="$(python3 -c 'import secrets;print(secrets.token_urlsafe(36).replace("-","").replace("_","")[:48])')"
+  save ORIGIN_VERIFY "$ORIGIN_VERIFY"
+  log "generated origin-verify header value"
+else
+  log "origin-verify value reused from state"
+fi
+
+# ------------------------------------------------------------------ SGs
+sg_ensure() {  # name description
+  local n="$1" d="$2" id
+  id="$(aws ec2 describe-security-groups --filters "Name=group-name,Values=$n" "Name=vpc-id,Values=$VPC_ID" \
+        --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo None)"
+  if [ "$id" = "None" ]; then
+    id="$(aws ec2 create-security-group --group-name "$n" --description "$d" --vpc-id "$VPC_ID" \
+          --query GroupId --output text)"
+    log "created sg $n -> $id" >&2
+  else
+    log "sg exists $n -> $id" >&2
+  fi
+  echo "$id"
+}
+ALB_SG="$(sg_ensure "$NAME-portal-alb" "ALB - CloudFront origin-facing traffic only")"
+SVC_SG="$(sg_ensure "$NAME-portal-service" "backend service")"
+save ALB_SG "$ALB_SG"; save SVC_SG "$SVC_SG"
+
+# CloudFront origin-facing managed prefix list
+PL_ID="$(aws ec2 describe-managed-prefix-lists \
+  --filters Name=prefix-list-name,Values=com.amazonaws.global.cloudfront.origin-facing \
+  --query 'PrefixLists[0].PrefixListId' --output text)"
+aws ec2 authorize-security-group-ingress --group-id "$ALB_SG" \
+  --ip-permissions "IpProtocol=tcp,FromPort=80,ToPort=80,PrefixListIds=[{PrefixListId=$PL_ID,Description=CloudFront origin-facing}]" \
+  >/dev/null 2>&1 || log "alb ingress already present"
+aws ec2 authorize-security-group-ingress --group-id "$SVC_SG" \
+  --ip-permissions "IpProtocol=tcp,FromPort=8000,ToPort=8000,UserIdGroupPairs=[{GroupId=$ALB_SG,Description=from ALB}]" \
+  >/dev/null 2>&1 || log "service ingress from alb already present"
+aws ec2 authorize-security-group-ingress --group-id "$SVC_SG" \
+  --ip-permissions "IpProtocol=tcp,FromPort=8000,ToPort=8000,IpRanges=[{CidrIp=$VPC_CIDR,Description=from service-entry NLB}]" \
+  >/dev/null 2>&1 || log "service ingress from vpc already present"
+
+# ------------------------------------------------------------------ ALBs
+alb_ensure() {  # name scheme subnets sg-or-empty type
+  local n="$1" scheme="$2" subnets="$3" sg="$4" type="$5" arn extra=""
+  arn="$(aws elbv2 describe-load-balancers --names "$n" --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null || echo None)"
+  if [ "$arn" != "None" ] && [ -n "$arn" ]; then log "lb exists $n" >&2; echo "$arn"; return 0; fi
+  [ -n "$sg" ] && extra="--security-groups $sg"
+  arn="$(aws elbv2 create-load-balancer --name "$n" --type "$type" --scheme "$scheme" \
+        --subnets $subnets $extra --query 'LoadBalancers[0].LoadBalancerArn' --output text)"
+  log "created $type lb $n" >&2
+  echo "$arn"
+}
+# ALB name has a 32-char limit — "agent-platform-cli-portal" fits, but the
+# terraform names plus a longer suffix would not; worth knowing before renaming.
+ALB_ARN="$(alb_ensure "${NAME}-portal" internet-facing "$PUB0 $PUB1" "$ALB_SG" application)"
+NLB_ARN="$(alb_ensure "${NAME}-svc-entry" internal "$PRIV0 $PRIV1" "" network)"
+save ALB_ARN "$ALB_ARN"; save NLB_ARN "$NLB_ARN"
+
+ALB_DNS="$(aws elbv2 describe-load-balancers --load-balancer-arns "$ALB_ARN" --query 'LoadBalancers[0].DNSName' --output text)"
+NLB_DNS="$(aws elbv2 describe-load-balancers --load-balancer-arns "$NLB_ARN" --query 'LoadBalancers[0].DNSName' --output text)"
+save ALB_DNS "$ALB_DNS"; save NLB_DNS "$NLB_DNS"
+
+# access logs on the ALB (the bucket policy from phase 2 admits the delivery principal)
+aws elbv2 modify-load-balancer-attributes --load-balancer-arn "$ALB_ARN" --attributes \
+  "Key=access_logs.s3.enabled,Value=true" "Key=access_logs.s3.bucket,Value=$LOGS_BUCKET" \
+  "Key=access_logs.s3.prefix,Value=alb" "Key=routing.http.drop_invalid_header_fields.enabled,Value=true" \
+  >/dev/null && log "alb access logs enabled"
+
+tg_ensure() {  # name protocol port target-type health-path
+  local n="$1" proto="$2" port="$3" tt="$4" hp="$5" arn
+  arn="$(aws elbv2 describe-target-groups --names "$n" --query 'TargetGroups[0].TargetGroupArn' --output text 2>/dev/null || echo None)"
+  if [ "$arn" != "None" ] && [ -n "$arn" ]; then log "tg exists $n" >&2; echo "$arn"; return 0; fi
+  arn="$(aws elbv2 create-target-group --name "$n" --protocol "$proto" --port "$port" \
+        --vpc-id "$VPC_ID" --target-type "$tt" \
+        --health-check-protocol HTTP --health-check-path "$hp" \
+        --health-check-interval-seconds 30 --healthy-threshold-count 2 --unhealthy-threshold-count 3 \
+        --query 'TargetGroups[0].TargetGroupArn' --output text)"
+  aws elbv2 modify-target-group-attributes --target-group-arn "$arn" \
+    --attributes Key=deregistration_delay.timeout_seconds,Value=30 >/dev/null
+  log "created tg $n" >&2
+  echo "$arn"
+}
+TG_ALB="$(tg_ensure "${NAME}-backend" HTTP 8000 ip /health)"
+TG_NLB="$(tg_ensure "${NAME}-svc-entry" TCP 8000 ip /health)"
+aws elbv2 modify-target-group-attributes --target-group-arn "$TG_NLB" \
+  --attributes Key=preserve_client_ip.enabled,Value=false >/dev/null 2>&1 || true
+save TG_ALB "$TG_ALB"; save TG_NLB "$TG_NLB"
+
+# ---- listeners: default-deny 403, forward only on the origin-verify header ----
+L_ALB="$(aws elbv2 describe-listeners --load-balancer-arn "$ALB_ARN" --query 'Listeners[0].ListenerArn' --output text 2>/dev/null || echo None)"
+if [ "$L_ALB" = "None" ] || [ -z "$L_ALB" ]; then
+  L_ALB="$(aws elbv2 create-listener --load-balancer-arn "$ALB_ARN" --protocol HTTP --port 80 \
+    --default-actions 'Type=fixed-response,FixedResponseConfig={MessageBody="Direct origin access is not allowed.",StatusCode=403,ContentType=text/plain}' \
+    --query 'Listeners[0].ListenerArn' --output text)"
+  log "created alb listener (default-deny)"
+else
+  log "alb listener exists"
+fi
+save L_ALB "$L_ALB"
+
+if ! aws elbv2 describe-rules --listener-arn "$L_ALB" --query 'Rules[?Priority==`100`]' --output text | grep -q .; then
+  aws elbv2 create-rule --listener-arn "$L_ALB" --priority 100 \
+    --conditions "Field=http-header,HttpHeaderConfig={HttpHeaderName=x-origin-verify,Values=[$ORIGIN_VERIFY]}" \
+    --actions "Type=forward,TargetGroupArn=$TG_ALB" >/dev/null
+  log "created origin-verify forward rule"
+else
+  log "origin-verify rule exists"
+fi
+
+L_NLB="$(aws elbv2 describe-listeners --load-balancer-arn "$NLB_ARN" --query 'Listeners[0].ListenerArn' --output text 2>/dev/null || echo None)"
+if [ "$L_NLB" = "None" ] || [ -z "$L_NLB" ]; then
+  aws elbv2 create-listener --load-balancer-arn "$NLB_ARN" --protocol TCP --port 80 \
+    --default-actions "Type=forward,TargetGroupArn=$TG_NLB" >/dev/null
+  log "created nlb listener"
+else
+  log "nlb listener exists"
+fi
+
+log "portal base done (alb=$ALB_DNS)"

--- a/deploy-cli/scripts/50-portal-app.sh
+++ b/deploy-cli/scripts/50-portal-app.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Phase 4b — ECS task/exec roles + service, CloudFront distribution (+OAC,
+# SPA function, origin-verify header), scheduler group/DLQ/Lambda, and the
+# private service-entry API. Mirrors the rest of terraform modules/portal.
+. "$(dirname "$0")/../lib/common.sh"
+load
+: "${ALB_ARN:?run 40-portal-base.sh}"; : "${TABLE:?run 20-platform.sh}"
+
+step "portal app ($NAME)"
+PRIV0="${PRIVATE_SUBNETS%%,*}"; PRIV1="${PRIVATE_SUBNETS##*,}"
+TABLE_ARN="arn:aws:dynamodb:$AWS_REGION:$ACCOUNT_ID:table/$TABLE"
+WS_ARN="arn:aws:s3:::$WORKSPACE_BUCKET"
+
+# ------------------------------------------------------------------ logs
+LOG_GROUP="/ecs/agent-platform-backend${SUFFIX}"
+aws logs create-log-group --log-group-name "$LOG_GROUP" >/dev/null 2>&1 || true
+aws logs put-retention-policy --log-group-name "$LOG_GROUP" --retention-in-days 7 >/dev/null
+LAMBDA_LG="/aws/lambda/agent-platform-schedule-runner${SUFFIX}"
+aws logs create-log-group --log-group-name "$LAMBDA_LG" >/dev/null 2>&1 || true
+aws logs put-retention-policy --log-group-name "$LAMBDA_LG" --retention-in-days 7 >/dev/null
+# Persist both: later phases reference them, and a derived-but-unsaved value is
+# invisible across script boundaries (terraform would just resolve the reference).
+save LOG_GROUP "$LOG_GROUP"
+save LAMBDA_LG "$LAMBDA_LG"
+log "log groups ready"
+
+# ------------------------------------------------------------------ scheduler infra
+SCHED_GROUP="agent-platform${SUFFIX}"
+aws scheduler create-schedule-group --name "$SCHED_GROUP" >/dev/null 2>&1 || log "schedule group exists"
+DLQ_NAME="agent-platform-schedule-dlq${SUFFIX}"
+DLQ_URL="$(aws sqs get-queue-url --queue-name "$DLQ_NAME" --query QueueUrl --output text 2>/dev/null || echo None)"
+if [ "$DLQ_URL" = "None" ]; then
+  DLQ_URL="$(aws sqs create-queue --queue-name "$DLQ_NAME" \
+    --attributes MessageRetentionPeriod=1209600 --query QueueUrl --output text)"
+  log "created dlq"
+fi
+DLQ_ARN="$(aws sqs get-queue-attributes --queue-url "$DLQ_URL" --attribute-names QueueArn --query 'Attributes.QueueArn' --output text)"
+save DLQ_URL "$DLQ_URL"; save DLQ_ARN "$DLQ_ARN"; save SCHED_GROUP "$SCHED_GROUP"
+
+# ------------------------------------------------------------------ IAM
+role_ensure() {  # name trust
+  local rn="$1" trust="$2" arn
+  arn="$(aws iam get-role --role-name "$rn" --query 'Role.Arn' --output text 2>/dev/null || echo None)"
+  if [ "$arn" = "None" ]; then
+    arn="$(aws iam create-role --role-name "$rn" --assume-role-policy-document "$trust" --query 'Role.Arn' --output text)"
+    log "created role $rn" >&2
+  else
+    log "role exists $rn" >&2
+  fi
+  echo "$arn"
+}
+ECS_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+LAMBDA_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+SCHED_TRUST="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"scheduler.amazonaws.com\"},\"Action\":\"sts:AssumeRole\",\"Condition\":{\"StringEquals\":{\"aws:SourceAccount\":\"$ACCOUNT_ID\"}}}]}"
+
+TASK_ROLE="$(role_ensure "agent-platform-backend-task${SUFFIX}" "$ECS_TRUST")"
+EXEC_ROLE="$(role_ensure "agent-platform-backend-exec${SUFFIX}" "$ECS_TRUST")"
+RUNNER_ROLE="$(role_ensure "agent-platform-schedule-runner${SUFFIX}" "$LAMBDA_TRUST")"
+SCHED_ROLE="$(role_ensure "agent-platform-scheduler${SUFFIX}" "$SCHED_TRUST")"
+save TASK_ROLE "$TASK_ROLE"; save EXEC_ROLE "$EXEC_ROLE"
+save RUNNER_ROLE "$RUNNER_ROLE"; save SCHED_ROLE "$SCHED_ROLE"
+
+ENTRY_SECRET_ARN_GUESS="arn:aws:secretsmanager:$AWS_REGION:$ACCOUNT_ID:secret:${ENTRY_SECRET}*"
+
+put_json_policy() {  # role name file
+  aws iam put-role-policy --role-name "$1" --policy-name "$2" --policy-document "file://$3"
+  log "policy $2 -> $1"
+}
+
+cat > /tmp/task-pol.json <<JSON
+{"Version":"2012-10-17","Statement":[
+ {"Sid":"DynamoRw","Effect":"Allow","Action":["dynamodb:BatchGetItem","dynamodb:GetItem","dynamodb:Query","dynamodb:Scan","dynamodb:ConditionCheckItem","dynamodb:BatchWriteItem","dynamodb:PutItem","dynamodb:UpdateItem","dynamodb:DeleteItem","dynamodb:DescribeTable"],"Resource":["$TABLE_ARN","$TABLE_ARN/index/*"]},
+ {"Sid":"WorkspaceBucketRw","Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:AbortMultipartUpload","s3:ListBucket","s3:GetBucketLocation"],"Resource":["$WS_ARN","$WS_ARN/*"]},
+ {"Sid":"AssumeWorkspaceAccess","Effect":"Allow","Action":"sts:AssumeRole","Resource":"$WORKSPACE_ROLE_ARN"},
+ {"Sid":"AgentCoreInvoke","Effect":"Allow","Action":["bedrock-agentcore:InvokeAgentRuntime","bedrock-agentcore:InvokeAgentRuntimeWithWebSocketStream","bedrock-agentcore:GetAgentRuntime","bedrock-agentcore:GetAgentRuntimeEndpoint"],"Resource":"arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:runtime/*"},
+ {"Sid":"AgentCoreMemory","Effect":"Allow","Action":["bedrock-agentcore:CreateMemory","bedrock-agentcore:GetMemory","bedrock-agentcore:UpdateMemory","bedrock-agentcore:DeleteMemory","bedrock-agentcore:GetEvent","bedrock-agentcore:ListEvents","bedrock-agentcore:ListActors","bedrock-agentcore:ListSessions","bedrock-agentcore:GetMemoryRecord","bedrock-agentcore:ListMemoryRecords","bedrock-agentcore:RetrieveMemoryRecords"],"Resource":"arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:memory/*"},
+ {"Sid":"AgentCoreMemoryList","Effect":"Allow","Action":"bedrock-agentcore:ListMemories","Resource":"*"},
+ {"Sid":"AgentCoreGatewayRead","Effect":"Allow","Action":["bedrock-agentcore:ListGateways","bedrock-agentcore:GetGateway","bedrock-agentcore:ListGatewayTargets","bedrock-agentcore:GetGatewayTarget"],"Resource":"*"},
+ {"Sid":"PipelineTraces","Effect":"Allow","Action":["xray:PutTraceSegments","xray:PutTelemetryRecords"],"Resource":"*"},
+ {"Sid":"SchedulerCrud","Effect":"Allow","Action":["scheduler:CreateSchedule","scheduler:UpdateSchedule","scheduler:DeleteSchedule","scheduler:GetSchedule","scheduler:ListSchedules"],"Resource":"arn:aws:scheduler:$AWS_REGION:$ACCOUNT_ID:schedule/$SCHED_GROUP/*"},
+ {"Sid":"PassSchedulerRole","Effect":"Allow","Action":"iam:PassRole","Resource":"$SCHED_ROLE","Condition":{"StringEquals":{"iam:PassedToService":"scheduler.amazonaws.com"}}},
+ {"Sid":"ServiceEntrySecret","Effect":"Allow","Action":["secretsmanager:GetSecretValue","secretsmanager:DescribeSecret"],"Resource":"$ENTRY_SECRET_ARN_GUESS"}]}
+JSON
+put_json_policy "agent-platform-backend-task${SUFFIX}" backend /tmp/task-pol.json
+
+cat > /tmp/exec-pol.json <<JSON
+{"Version":"2012-10-17","Statement":[
+ {"Sid":"EcrAuth","Effect":"Allow","Action":"ecr:GetAuthorizationToken","Resource":"*"},
+ {"Sid":"EcrPull","Effect":"Allow","Action":["ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Resource":"arn:aws:ecr:$AWS_REGION:$ACCOUNT_ID:repository/agent-platform${SUFFIX}/backend"},
+ {"Sid":"Logs","Effect":"Allow","Action":["logs:CreateLogStream","logs:PutLogEvents"],"Resource":"arn:aws:logs:$AWS_REGION:$ACCOUNT_ID:log-group:$LOG_GROUP:*"}]}
+JSON
+put_json_policy "agent-platform-backend-exec${SUFFIX}" execution /tmp/exec-pol.json
+
+cat > /tmp/runner-pol.json <<JSON
+{"Version":"2012-10-17","Statement":[
+ {"Sid":"Logs","Effect":"Allow","Action":["logs:CreateLogStream","logs:PutLogEvents"],"Resource":"arn:aws:logs:$AWS_REGION:$ACCOUNT_ID:log-group:$LAMBDA_LG:*"},
+ {"Sid":"DynamoRw","Effect":"Allow","Action":["dynamodb:BatchGetItem","dynamodb:GetItem","dynamodb:Query","dynamodb:Scan","dynamodb:ConditionCheckItem","dynamodb:BatchWriteItem","dynamodb:PutItem","dynamodb:UpdateItem","dynamodb:DeleteItem","dynamodb:DescribeTable"],"Resource":["$TABLE_ARN","$TABLE_ARN/index/*"]},
+ {"Sid":"WorkspaceBucketRw","Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:AbortMultipartUpload","s3:ListBucket","s3:GetBucketLocation"],"Resource":["$WS_ARN","$WS_ARN/*"]},
+ {"Sid":"AgentCoreInvoke","Effect":"Allow","Action":"bedrock-agentcore:InvokeAgentRuntime","Resource":"arn:aws:bedrock-agentcore:$AWS_REGION:$ACCOUNT_ID:runtime/*"},
+ {"Sid":"PipelineTraces","Effect":"Allow","Action":["xray:PutTraceSegments","xray:PutTelemetryRecords"],"Resource":"*"},
+ {"Sid":"PortalAdminSecret","Effect":"Allow","Action":"secretsmanager:GetSecretValue","Resource":"arn:aws:secretsmanager:$AWS_REGION:$ACCOUNT_ID:secret:agent-platform${SUFFIX}/portal-admin*"}]}
+JSON
+put_json_policy "agent-platform-schedule-runner${SUFFIX}" runner /tmp/runner-pol.json
+
+log "portal app IAM done"
+
+# ------------------------------------------------------------------ scheduler role policy
+cat > /tmp/sched-pol.json <<JSON
+{"Version":"2012-10-17","Statement":[
+ {"Sid":"InvokeRunner","Effect":"Allow","Action":"lambda:InvokeFunction","Resource":["arn:aws:lambda:$AWS_REGION:$ACCOUNT_ID:function:agent-platform-schedule-runner${SUFFIX}","arn:aws:lambda:$AWS_REGION:$ACCOUNT_ID:function:agent-platform-schedule-runner${SUFFIX}:*"]},
+ {"Sid":"DlqSend","Effect":"Allow","Action":"sqs:SendMessage","Resource":"$DLQ_ARN"}]}
+JSON
+put_json_policy "agent-platform-scheduler${SUFFIX}" scheduler /tmp/sched-pol.json
+
+# ------------------------------------------------------------------ entry secret
+if ! aws secretsmanager describe-secret --secret-id "$ENTRY_SECRET" >/dev/null 2>&1; then
+  ENTRY_VAL="$(python3 -c 'import secrets;print(secrets.token_urlsafe(40).replace("-","").replace("_","")[:48])')"
+  aws secretsmanager create-secret --name "$ENTRY_SECRET" \
+    --description "Shared header secret: service-entry API Gateway -> backend" \
+    --secret-string "$ENTRY_VAL" >/dev/null
+  log "created service-entry secret"
+else
+  ENTRY_VAL="$(aws secretsmanager get-secret-value --secret-id "$ENTRY_SECRET" --query SecretString --output text)"
+  log "service-entry secret exists"
+fi
+save ENTRY_SECRET "$ENTRY_SECRET"; save ENTRY_VAL "$ENTRY_VAL"
+
+# ------------------------------------------------------------------ schedule-runner lambda
+FN="agent-platform-schedule-runner${SUFFIX}"
+if ! aws lambda get-function --function-name "$FN" >/dev/null 2>&1; then
+  # Placeholder code, same split as terraform: infra here, real package via
+  # scripts/deploy-schedule-lambda.sh.
+  mkdir -p /tmp/lam && printf 'def handler(event, context):\n    raise RuntimeError("schedule-runner code not deployed")\n' > /tmp/lam/index.py
+  (cd /tmp/lam && rm -f f.zip && zip -q f.zip index.py)
+  aws lambda create-function --function-name "$FN" --runtime python3.13 --architectures arm64 \
+    --role "$RUNNER_ROLE" --handler index.handler --timeout 600 --memory-size 512 \
+    --zip-file fileb:///tmp/lam/f.zip \
+    --logging-config "LogFormat=Text,LogGroup=$LAMBDA_LG" >/dev/null 2>&1 \
+    || { log "lambda create failed once (role propagation) — retrying in 15s"
+         sleep 15
+         aws lambda create-function --function-name "$FN" --runtime python3.13 --architectures arm64 \
+           --role "$RUNNER_ROLE" --handler index.handler --timeout 600 --memory-size 512 \
+           --zip-file fileb:///tmp/lam/f.zip \
+           --logging-config "LogFormat=Text,LogGroup=$LAMBDA_LG" >/dev/null; }
+  log "created schedule-runner lambda (placeholder code)"
+else
+  log "lambda exists $FN"
+fi
+LAMBDA_ARN="$(aws lambda get-function --function-name "$FN" --query 'Configuration.FunctionArn' --output text)"
+save LAMBDA_ARN "$LAMBDA_ARN"; save SCHEDULE_FN "$FN"
+
+log "portal app phase 1 done"

--- a/deploy-cli/scripts/60-cloudfront-ecs.sh
+++ b/deploy-cli/scripts/60-cloudfront-ecs.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Phase 5 — CloudFront (OAC + SPA function + origin-verify header), then the ECS
+# cluster/task-definition/service. CloudFront comes first because the backend's
+# CORS origin is its domain, which does not exist until the distribution does —
+# terraform resolves that ordering from the graph; here it is script order.
+. "$(dirname "$0")/../lib/common.sh"
+load
+: "${ALB_DNS:?run 40-portal-base.sh}"; : "${TASK_ROLE:?run 50-portal-app.sh}"
+# Recompute rather than require it in state, so this phase is runnable standalone.
+LOG_GROUP="${LOG_GROUP:-/ecs/agent-platform-backend${SUFFIX}}"
+
+step "cloudfront + ecs ($NAME)"
+PRIV0="${PRIVATE_SUBNETS%%,*}"; PRIV1="${PRIVATE_SUBNETS##*,}"
+
+# ------------------------------------------------------------------ OAC
+OAC_ID="$(aws cloudfront list-origin-access-controls \
+  --query "OriginAccessControlList.Items[?Name=='$NAME-frontend'].Id | [0]" --output text 2>/dev/null || echo None)"
+if [ "$OAC_ID" = "None" ] || [ -z "$OAC_ID" ]; then
+  OAC_ID="$(aws cloudfront create-origin-access-control --origin-access-control-config \
+    "Name=$NAME-frontend,Description=frontend OAC,SigningProtocol=sigv4,SigningBehavior=always,OriginAccessControlOriginType=s3" \
+    --query 'OriginAccessControl.Id' --output text)"
+  log "created OAC $OAC_ID"
+else
+  log "OAC exists $OAC_ID"
+fi
+save OAC_ID "$OAC_ID"
+
+# ------------------------------------------------------------------ SPA function
+FN_NAME="$NAME-spa-rewrite"
+FN_ETAG="$(aws cloudfront describe-function --name "$FN_NAME" --query 'ETag' --output text 2>/dev/null || echo None)"
+if [ "$FN_ETAG" = "None" ]; then
+  cat > /tmp/spa.js <<'JS'
+function handler(event) {
+  var request = event.request;
+  if (!request.uri.includes('.')) { request.uri = '/index.html'; }
+  return request;
+}
+JS
+  FN_ARN="$(aws cloudfront create-function --name "$FN_NAME" \
+    --function-config "Comment=SPA rewrite,Runtime=cloudfront-js-2.0" \
+    --function-code fileb:///tmp/spa.js --query 'FunctionSummary.FunctionMetadata.FunctionARN' --output text)"
+  ETAG="$(aws cloudfront describe-function --name "$FN_NAME" --query ETag --output text)"
+  aws cloudfront publish-function --name "$FN_NAME" --if-match "$ETAG" >/dev/null
+  log "created+published SPA function"
+else
+  FN_ARN="$(aws cloudfront describe-function --name "$FN_NAME" --query 'FunctionSummary.FunctionMetadata.FunctionARN' --output text)"
+  log "SPA function exists"
+fi
+save SPA_FN_ARN "$FN_ARN"
+
+# managed policy ids (stable, but resolve them rather than hardcoding)
+CACHE_OPT="$(aws cloudfront list-cache-policies --type managed \
+  --query "CachePolicyList.Items[?CachePolicy.CachePolicyConfig.Name=='Managed-CachingOptimized'].CachePolicy.Id | [0]" --output text)"
+CACHE_DIS="$(aws cloudfront list-cache-policies --type managed \
+  --query "CachePolicyList.Items[?CachePolicy.CachePolicyConfig.Name=='Managed-CachingDisabled'].CachePolicy.Id | [0]" --output text)"
+ORP_ALL="$(aws cloudfront list-origin-request-policies --type managed \
+  --query "OriginRequestPolicyList.Items[?OriginRequestPolicy.OriginRequestPolicyConfig.Name=='Managed-AllViewerExceptHostHeader'].OriginRequestPolicy.Id | [0]" --output text)"
+log "cache policies: opt=$CACHE_OPT disabled=$CACHE_DIS orp=$ORP_ALL"
+
+# ------------------------------------------------------------------ distribution
+DIST_ID="$(aws cloudfront list-distributions \
+  --query "DistributionList.Items[?Comment=='$NAME'].Id | [0]" --output text 2>/dev/null || echo None)"
+if [ "$DIST_ID" = "None" ] || [ -z "$DIST_ID" ]; then
+  python3 - "$NAME" "$FRONTEND_BUCKET" "$AWS_REGION" "$ALB_DNS" "$OAC_ID" "$FN_ARN" \
+           "$CACHE_OPT" "$CACHE_DIS" "$ORP_ALL" "$ORIGIN_VERIFY" > /tmp/dist.json <<'PY'
+import json, sys
+name, bucket, region, alb, oac, fn, copt, cdis, orp, verify = sys.argv[1:11]
+api_behavior = {
+    "TargetOriginId": "backend-alb",
+    "ViewerProtocolPolicy": "redirect-to-https",
+    "AllowedMethods": {"Quantity": 7,
+        "Items": ["GET","HEAD","OPTIONS","PUT","POST","PATCH","DELETE"],
+        "CachedMethods": {"Quantity": 2, "Items": ["GET","HEAD"]}},
+    "CachePolicyId": cdis,
+    "OriginRequestPolicyId": orp,
+    "Compress": True,
+}
+cfg = {
+  "CallerReference": f"{name}-1",
+  "Comment": name,
+  "Enabled": True,
+  "DefaultRootObject": "index.html",
+  "IsIPV6Enabled": True,
+  "Origins": {"Quantity": 2, "Items": [
+    {"Id": "frontend-s3",
+     "DomainName": f"{bucket}.s3.{region}.amazonaws.com",
+     "OriginAccessControlId": oac,
+     "S3OriginConfig": {"OriginAccessIdentity": ""}},
+    {"Id": "backend-alb", "DomainName": alb,
+     # Proves to the ALB that the request came through THIS distribution; the
+     # listener default-denies without it.
+     "CustomHeaders": {"Quantity": 1, "Items": [
+        {"HeaderName": "x-origin-verify", "HeaderValue": verify}]},
+     "CustomOriginConfig": {"HTTPPort": 80, "HTTPSPort": 443,
+        "OriginProtocolPolicy": "http-only",
+        "OriginSslProtocols": {"Quantity": 1, "Items": ["TLSv1.2"]},
+        "OriginReadTimeout": 60, "OriginKeepaliveTimeout": 5}},
+  ]},
+  "DefaultCacheBehavior": {
+    "TargetOriginId": "frontend-s3",
+    "ViewerProtocolPolicy": "redirect-to-https",
+    "AllowedMethods": {"Quantity": 2, "Items": ["GET","HEAD"],
+                       "CachedMethods": {"Quantity": 2, "Items": ["GET","HEAD"]}},
+    "CachePolicyId": copt,
+    "Compress": True,
+    "FunctionAssociations": {"Quantity": 1, "Items": [
+        {"EventType": "viewer-request", "FunctionARN": fn}]},
+  },
+  "CacheBehaviors": {"Quantity": 2, "Items": [
+    dict(api_behavior, PathPattern="/api/*"),
+    dict(api_behavior, PathPattern="/health"),
+  ]},
+  "Restrictions": {"GeoRestriction": {"RestrictionType": "none", "Quantity": 0}},
+  "ViewerCertificate": {"CloudFrontDefaultCertificate": True},
+}
+json.dump({"DistributionConfig": cfg}, sys.stdout)
+PY
+  DIST_ID="$(aws cloudfront create-distribution --cli-input-json file:///tmp/dist.json \
+    --query 'Distribution.Id' --output text)"
+  log "created distribution $DIST_ID"
+else
+  log "distribution exists $DIST_ID"
+fi
+save DIST_ID "$DIST_ID"
+DIST_DOMAIN="$(aws cloudfront get-distribution --id "$DIST_ID" --query 'Distribution.DomainName' --output text)"
+DIST_ARN="arn:aws:cloudfront::$ACCOUNT_ID:distribution/$DIST_ID"
+save DIST_DOMAIN "$DIST_DOMAIN"; save PORTAL_URL "https://$DIST_DOMAIN"
+
+# frontend bucket policy: OAC read pinned to THIS distribution + TLS only
+cat > /tmp/fe-pol.json <<JSON
+{"Version":"2012-10-17","Statement":[
+ {"Sid":"AllowCloudFrontOAC","Effect":"Allow","Principal":{"Service":"cloudfront.amazonaws.com"},
+  "Action":"s3:GetObject","Resource":"arn:aws:s3:::$FRONTEND_BUCKET/*",
+  "Condition":{"StringEquals":{"AWS:SourceArn":"$DIST_ARN"}}},
+ {"Sid":"EnforceTLS","Effect":"Deny","Principal":{"AWS":"*"},"Action":"s3:*",
+  "Resource":["arn:aws:s3:::$FRONTEND_BUCKET","arn:aws:s3:::$FRONTEND_BUCKET/*"],
+  "Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}
+JSON
+aws s3api put-bucket-policy --bucket "$FRONTEND_BUCKET" --policy file:///tmp/fe-pol.json
+log "frontend bucket policy pinned to $DIST_ID"
+
+# ------------------------------------------------------------------ ECS
+CLUSTER="agent-platform${SUFFIX}"
+aws ecs create-cluster --cluster-name "$CLUSTER" >/dev/null 2>&1 || true
+save CLUSTER "$CLUSTER"
+
+BACKEND_IMAGE="${REGISTRY}/agent-platform${SUFFIX}/backend:${IMAGE_TAG}"
+SVC_API_ID_PLACEHOLDER="${SERVICE_API_ID:-}"
+python3 - > /tmp/taskdef.json <<PY
+import json, os
+env = {
+  "PLATFORM_AWS_REGION": "$AWS_REGION",
+  "PLATFORM_DYNAMO_TABLE": "$TABLE",
+  "PLATFORM_WORKSPACE_BUCKET": "$WORKSPACE_BUCKET",
+  "PLATFORM_INTERACTIVE_RUNTIME_ARN": "$INTERACTIVE_RUNTIME_ARN",
+  "PLATFORM_SDK_RUNTIME_ARN": "$SDK_RUNTIME_ARN",
+  "PLATFORM_MCP_TOOLS_RUNTIME_ARN": "$MCP_TOOLS_RUNTIME_ARN",
+  "PLATFORM_WORKSPACE_ACCESS_ROLE_ARN": "$WORKSPACE_ROLE_ARN",
+  # Scoped to this distribution, not "*" — matches the upstream hardening.
+  "PLATFORM_CORS_ORIGINS": "https://$DIST_DOMAIN",
+  "PLATFORM_COGNITO_POOL_ID": "$POOL_ID",
+  "PLATFORM_COGNITO_CLIENT_ID": "$CLIENT_ID",
+  "PLATFORM_SCHEDULER_GROUP": "$SCHED_GROUP",
+  "PLATFORM_SCHEDULER_LAMBDA_ARN": "$LAMBDA_ARN",
+  "PLATFORM_SCHEDULER_ROLE_ARN": "$SCHED_ROLE",
+  "PLATFORM_SCHEDULER_DLQ_ARN": "$DLQ_ARN",
+  "PLATFORM_SERVICE_ENTRY_SECRET_NAME": "$ENTRY_SECRET",
+  "PLATFORM_PORTAL_API_URL": "https://$DIST_DOMAIN",
+}
+task = {
+  "family": "agent-platform-backend${SUFFIX}",
+  "cpu": "512", "memory": "1024",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "taskRoleArn": "$TASK_ROLE",
+  "executionRoleArn": "$EXEC_ROLE",
+  "runtimePlatform": {"operatingSystemFamily": "LINUX", "cpuArchitecture": "ARM64"},
+  "containerDefinitions": [{
+    "name": "backend",
+    "image": "$BACKEND_IMAGE",
+    "essential": True,
+    "portMappings": [{"containerPort": 8000, "protocol": "tcp"}],
+    "environment": [{"name": k, "value": v} for k, v in sorted(env.items())],
+    "logConfiguration": {"logDriver": "awslogs", "options": {
+      "awslogs-group": "$LOG_GROUP",
+      "awslogs-region": "$AWS_REGION",
+      "awslogs-stream-prefix": "backend"}},
+  }],
+}
+print(json.dumps(task))
+PY
+TD_ARN="$(aws ecs register-task-definition --cli-input-json file:///tmp/taskdef.json \
+  --query 'taskDefinition.taskDefinitionArn' --output text)"
+save TD_ARN "$TD_ARN"
+log "registered task definition"
+
+SVC="agent-platform-backend${SUFFIX}"
+EXISTING="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SVC" \
+  --query 'services[?status==`ACTIVE`].serviceName | [0]' --output text 2>/dev/null || echo None)"
+if [ "$EXISTING" = "None" ] || [ -z "$EXISTING" ]; then
+  aws ecs create-service --cluster "$CLUSTER" --service-name "$SVC" \
+    --task-definition "$TD_ARN" --desired-count 2 --launch-type FARGATE \
+    --network-configuration "awsvpcConfiguration={subnets=[$PRIV0,$PRIV1],securityGroups=[$SVC_SG],assignPublicIp=DISABLED}" \
+    --load-balancers "targetGroupArn=$TG_ALB,containerName=backend,containerPort=8000" \
+                     "targetGroupArn=$TG_NLB,containerName=backend,containerPort=8000" \
+    --deployment-configuration 'deploymentCircuitBreaker={enable=true,rollback=true}' >/dev/null
+  log "created ecs service (2 tasks, circuit breaker on)"
+else
+  aws ecs update-service --cluster "$CLUSTER" --service "$SVC" --task-definition "$TD_ARN" >/dev/null
+  log "updated ecs service to new task definition"
+fi
+save SERVICE "$SVC"
+
+log "cloudfront+ecs done — portal will be https://$DIST_DOMAIN"

--- a/deploy-cli/scripts/70-service-entry.sh
+++ b/deploy-cli/scripts/70-service-entry.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Phase 6 — the private service-entry API: PRIVATE REST API -> VPC Link ->
+# internal NLB, SigV4 (AWS_IAM) auth, gateway-injected caller ARN + shared
+# secret. Mirrors terraform modules/portal/service_entry.tf.
+. "$(dirname "$0")/../lib/common.sh"
+load
+: "${NLB_ARN:?run 40-portal-base.sh}"; : "${ENTRY_VAL:?run 50-portal-app.sh}"
+
+step "service entry ($NAME)"
+
+# ---- VPC Link (takes several minutes; a create against a pending link fails) ----
+VPCLINK_ID="$(aws apigateway get-vpc-links \
+  --query "items[?name=='agent-platform-service-entry${SUFFIX}'].id | [0]" --output text 2>/dev/null || echo None)"
+if [ "$VPCLINK_ID" = "None" ] || [ -z "$VPCLINK_ID" ]; then
+  VPCLINK_ID="$(aws apigateway create-vpc-link --name "agent-platform-service-entry${SUFFIX}" \
+    --description "agent-platform service entry -> internal NLB" \
+    --target-arns "$NLB_ARN" --query id --output text)"
+  log "creating vpc link $VPCLINK_ID (several minutes)"
+else
+  log "vpc link exists $VPCLINK_ID"
+fi
+save VPCLINK_ID "$VPCLINK_ID"
+
+for i in $(seq 1 60); do
+  ST="$(aws apigateway get-vpc-link --vpc-link-id "$VPCLINK_ID" --query status --output text 2>/dev/null)"
+  [ "$ST" = "AVAILABLE" ] && { log "vpc link AVAILABLE"; break; }
+  [ "$ST" = "FAILED" ] && die "vpc link FAILED"
+  sleep 15
+done
+
+# ---- REST API (PRIVATE) ----
+API_ID="$(aws apigateway get-rest-apis \
+  --query "items[?name=='agent-platform-service-entry${SUFFIX}'].id | [0]" --output text 2>/dev/null || echo None)"
+if [ "$API_ID" = "None" ] || [ -z "$API_ID" ]; then
+  API_ID="$(aws apigateway create-rest-api --name "agent-platform-service-entry${SUFFIX}" \
+    --description "SigV4-authenticated server-to-server entry to agent channels (private)" \
+    --endpoint-configuration 'types=PRIVATE' --query id --output text)"
+  log "created private rest api $API_ID"
+else
+  log "rest api exists $API_ID"
+fi
+save SERVICE_API_ID "$API_ID"
+
+# Resource policy: this account only. Attached AFTER create (upstream ae481cd
+# moved terraform to the same shape, because an inline policy embeds the API id
+# which does not exist yet).
+cat > /tmp/api-pol.json <<JSON
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::$ACCOUNT_ID:root"},"Action":"execute-api:Invoke","Resource":"arn:aws:execute-api:$AWS_REGION:$ACCOUNT_ID:$API_ID/*"}]}
+JSON
+aws apigateway update-rest-api --rest-api-id "$API_ID" \
+  --patch-operations "op=replace,path=/policy,value=$(python3 -c 'import json,sys;print(json.dumps(open("/tmp/api-pol.json").read()))')" \
+  >/dev/null && log "resource policy attached"
+
+ROOT_ID="$(aws apigateway get-resources --rest-api-id "$API_ID" --query "items[?path=='/'].id | [0]" --output text)"
+
+res_ensure() {  # parent-id path-part
+  local parent="$1" part="$2" id
+  id="$(aws apigateway get-resources --rest-api-id "$API_ID" --limit 200 \
+        --query "items[?pathPart=='$part' && parentId=='$parent'].id | [0]" --output text 2>/dev/null || echo None)"
+  if [ "$id" = "None" ] || [ -z "$id" ]; then
+    id="$(aws apigateway create-resource --rest-api-id "$API_ID" --parent-id "$parent" \
+          --path-part "$part" --query id --output text)"
+  fi
+  echo "$id"
+}
+R_SERVICE="$(res_ensure "$ROOT_ID" service)"
+R_V1="$(res_ensure "$R_SERVICE" v1)"
+R_CHANNELS="$(res_ensure "$R_V1" channels)"
+R_CHID="$(res_ensure "$R_CHANNELS" '{channelId}')"
+R_CHINV="$(res_ensure "$R_CHID" invocations)"
+R_INVS="$(res_ensure "$R_V1" invocations)"
+R_INVID="$(res_ensure "$R_INVS" '{invocationId}')"
+log "resources created"
+
+method_and_integration() {  # resource-id http-method path-param uri-suffix
+  local rid="$1" verb="$2" param="$3" suffix="$4"
+  aws apigateway put-method --rest-api-id "$API_ID" --resource-id "$rid" \
+    --http-method "$verb" --authorization-type AWS_IAM \
+    --request-parameters "method.request.path.$param=true" >/dev/null 2>&1 \
+    || log "method $verb exists"
+  # --request-parameters as key=value,key=value shorthand breaks here: the
+  # generated secret can contain characters the CLI parses as part of the
+  # mapping expression, producing "Invalid mapping expression specified" with the
+  # secret echoed back. Pass JSON instead. (Single quotes around the value mark
+  # it as a STATIC value to API Gateway, as opposed to a context lookup.)
+  python3 - "$param" "$ENTRY_VAL" > /tmp/reqparams.json <<'PYP'
+import json, sys
+param, secret = sys.argv[1], sys.argv[2]
+json.dump({
+    "integration.request.header.x-caller-arn": "context.identity.userArn",
+    "integration.request.header.x-service-entry-secret": f"'{secret}'",
+    f"integration.request.path.{param}": f"method.request.path.{param}",
+}, sys.stdout)
+PYP
+  aws apigateway put-integration --rest-api-id "$API_ID" --resource-id "$rid" \
+    --http-method "$verb" --type HTTP_PROXY --integration-http-method "$verb" \
+    --uri "http://${NLB_DNS}${suffix}" \
+    --connection-type VPC_LINK --connection-id "$VPCLINK_ID" \
+    --request-parameters file:///tmp/reqparams.json \
+    >/dev/null && log "integration $verb $suffix"
+}
+method_and_integration "$R_CHINV" POST channelId '/service/v1/channels/{channelId}/invocations'
+method_and_integration "$R_INVID" GET invocationId '/service/v1/invocations/{invocationId}'
+
+# ---- deployment + stage with access logging ----
+ACCESS_LG="/aws/apigateway/agent-platform-service-entry${SUFFIX}"
+aws logs create-log-group --log-group-name "$ACCESS_LG" >/dev/null 2>&1 || true
+aws logs put-retention-policy --log-group-name "$ACCESS_LG" --retention-in-days 30 >/dev/null
+
+DEP_ID="$(aws apigateway create-deployment --rest-api-id "$API_ID" --query id --output text)"
+log "created deployment $DEP_ID"
+
+if aws apigateway get-stage --rest-api-id "$API_ID" --stage-name svc >/dev/null 2>&1; then
+  aws apigateway update-stage --rest-api-id "$API_ID" --stage-name svc \
+    --patch-operations "op=replace,path=/deploymentId,value=$DEP_ID" >/dev/null
+  log "stage svc updated"
+else
+  # PREREQUISITE: API Gateway only writes access logs once the ACCOUNT has
+  # cloudwatchRoleArn set. Terraform cannot set it per-stack either; if the
+  # create fails on that, fall back to a stage without logging rather than
+  # leaving no stage at all.
+  # Access logging has two CLI-only traps:
+  #  1. --patch-operations shorthand cannot carry a JSON format string (the
+  #     quotes are parsed as part of the key=value expression), so this goes
+  #     through --cli-input-json.
+  #  2. describe-log-groups returns the group ARN with a trailing ":*", which
+  #     API Gateway rejects as "Invalid ARN specified" — it wants it stripped.
+  # It also needs an ACCOUNT-level cloudwatchRoleArn; if that is unset, create
+  # the stage without logging rather than leaving no stage at all.
+  aws apigateway create-stage --rest-api-id "$API_ID" --stage-name svc --deployment-id "$DEP_ID" >/dev/null
+  log "stage svc created"
+fi
+
+LG_ARN="$(aws logs describe-log-groups --log-group-name-prefix "$ACCESS_LG" \
+  --query 'logGroups[0].arn' --output text 2>/dev/null || echo None)"
+if [ "$LG_ARN" != "None" ] && [ -n "$LG_ARN" ]; then
+  python3 - "$API_ID" "$LG_ARN" > /tmp/stage-log.json <<'PYS'
+import json, sys
+api, lg = sys.argv[1:3]
+lg = lg[:-2] if lg.endswith(":*") else lg
+fmt = json.dumps({
+    "requestId": "$context.requestId", "ip": "$context.identity.sourceIp",
+    "callerArn": "$context.identity.userArn", "vpce": "$context.identity.vpceId",
+    "httpMethod": "$context.httpMethod", "resourcePath": "$context.resourcePath",
+    "status": "$context.status", "requestTime": "$context.requestTime",
+})
+json.dump({"restApiId": api, "stageName": "svc", "patchOperations": [
+    {"op": "replace", "path": "/accessLogSettings/destinationArn", "value": lg},
+    {"op": "replace", "path": "/accessLogSettings/format", "value": fmt}]}, sys.stdout)
+PYS
+  if aws apigateway update-stage --cli-input-json file:///tmp/stage-log.json >/dev/null 2>&1; then
+    log "stage access logging enabled"
+  else
+    warn "could not enable stage access logging; the account may need:"
+    warn "  aws apigateway update-account --patch-operations op=replace,path=/cloudwatchRoleArn,value=<role-arn>"
+  fi
+fi
+
+aws apigateway update-stage --rest-api-id "$API_ID" --stage-name svc \
+  --patch-operations 'op=replace,path=/*/*/throttling/rateLimit,value=50' \
+                     'op=replace,path=/*/*/throttling/burstLimit,value=100' >/dev/null 2>&1 \
+  || log "throttle settings unchanged"
+
+save SERVICE_API_URL "https://${API_ID}.execute-api.${AWS_REGION}.amazonaws.com/svc/"
+log "service entry done: $SERVICE_API_URL"

--- a/deploy-cli/scripts/99-destroy.sh
+++ b/deploy-cli/scripts/99-destroy.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Tear down the CLI environment, in reverse dependency order.
+#
+# Deliberately NOT a mirror of the deploy scripts: several resources refuse to go
+# while something references them, and a few need a disable-then-wait step that
+# has no counterpart on the way up. Run with CONFIRM=yes.
+#
+# Order matters: ECS service (drain) -> ALB/NLB listeners+LBs -> target groups ->
+# CloudFront (disable, wait, delete) -> API GW + VPC Link -> runtimes -> Lambda/
+# scheduler -> Cognito -> buckets -> table -> ECR -> IAM -> NAT -> subnets -> VPC.
+set -uo pipefail
+. "$(dirname "$0")/../lib/common.sh"
+load
+
+[ "${CONFIRM:-no}" = "yes" ] || die "refusing to destroy without CONFIRM=yes"
+step "DESTROY $NAME"
+
+t() { "$@" >/dev/null 2>&1 && log "ok: $*" || log "skip/failed: $*"; }
+
+# ---- ECS ----
+if [ -n "${CLUSTER:-}" ] && [ -n "${SERVICE:-}" ]; then
+  t aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" --desired-count 0
+  log "waiting for tasks to drain…"
+  aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE" 2>/dev/null || true
+  t aws ecs delete-service --cluster "$CLUSTER" --service "$SERVICE" --force
+  t aws ecs delete-cluster --cluster "$CLUSTER"
+fi
+
+# ---- load balancers (listeners die with the LB; target groups must follow it) ----
+for arn in "${ALB_ARN:-}" "${NLB_ARN:-}"; do
+  [ -n "$arn" ] && t aws elbv2 delete-load-balancer --load-balancer-arn "$arn"
+done
+sleep 25   # target groups stay "in use" briefly after the LB goes
+for arn in "${TG_ALB:-}" "${TG_NLB:-}"; do
+  [ -n "$arn" ] && t aws elbv2 delete-target-group --target-group-arn "$arn"
+done
+
+# ---- CloudFront: must be disabled and fully deployed before it can be deleted ----
+if [ -n "${DIST_ID:-}" ]; then
+  ETAG="$(aws cloudfront get-distribution-config --id "$DIST_ID" --query ETag --output text 2>/dev/null || echo '')"
+  if [ -n "$ETAG" ]; then
+    aws cloudfront get-distribution-config --id "$DIST_ID" \
+      --query 'DistributionConfig' > /tmp/d.json 2>/dev/null
+    python3 -c "
+import json;d=json.load(open('/tmp/d.json'));d['Enabled']=False
+json.dump(d,open('/tmp/d.json','w'))"
+    t aws cloudfront update-distribution --id "$DIST_ID" --distribution-config file:///tmp/d.json --if-match "$ETAG"
+    log "waiting for distribution to finish disabling (can take ~5 min)…"
+    aws cloudfront wait distribution-deployed --id "$DIST_ID" 2>/dev/null || true
+    ETAG2="$(aws cloudfront get-distribution-config --id "$DIST_ID" --query ETag --output text 2>/dev/null || echo '')"
+    t aws cloudfront delete-distribution --id "$DIST_ID" --if-match "$ETAG2"
+  fi
+fi
+t aws cloudfront delete-function --name "$NAME-spa-rewrite" \
+  --if-match "$(aws cloudfront describe-function --name "$NAME-spa-rewrite" --query ETag --output text 2>/dev/null || echo x)"
+[ -n "${OAC_ID:-}" ] && t aws cloudfront delete-origin-access-control --id "$OAC_ID" \
+  --if-match "$(aws cloudfront get-origin-access-control --id "$OAC_ID" --query ETag --output text 2>/dev/null || echo x)"
+
+# ---- API GW + VPC link ----
+[ -n "${SERVICE_API_ID:-}" ] && t aws apigateway delete-rest-api --rest-api-id "$SERVICE_API_ID"
+[ -n "${VPCLINK_ID:-}" ] && t aws apigateway delete-vpc-link --vpc-link-id "$VPCLINK_ID"
+
+# ---- AgentCore runtimes ----
+for n in claude_code_kernel agent_sdk_kernel mcp_tools_kernel; do
+  id="$(aws bedrock-agentcore-control list-agent-runtimes \
+        --query "agentRuntimes[?agentRuntimeName=='${n}${RUNTIME_SUFFIX}'].agentRuntimeId | [0]" --output text 2>/dev/null)"
+  [ -n "$id" ] && [ "$id" != "None" ] && t aws bedrock-agentcore-control delete-agent-runtime --agent-runtime-id "$id"
+done
+
+# ---- lambda / scheduler / dlq ----
+[ -n "${SCHEDULE_FN:-}" ] && t aws lambda delete-function --function-name "$SCHEDULE_FN"
+[ -n "${SCHED_GROUP:-}" ] && t aws scheduler delete-schedule-group --name "$SCHED_GROUP"
+[ -n "${DLQ_URL:-}" ] && t aws sqs delete-queue --queue-url "$DLQ_URL"
+
+# ---- cognito ----
+[ -n "${POOL_ID:-}" ] && t aws cognito-idp delete-user-pool --user-pool-id "$POOL_ID"
+
+# ---- buckets (must be emptied first; versioned buckets need versions purged) ----
+for b in "${FRONTEND_BUCKET:-}" "${LOGS_BUCKET:-}" "${WORKSPACE_BUCKET:-}"; do
+  [ -z "$b" ] && continue
+  log "emptying $b"
+  aws s3 rm "s3://$b" --recursive >/dev/null 2>&1 || true
+  python3 - "$b" <<'PY' 2>/dev/null || true
+import json,subprocess,sys
+b=sys.argv[1]
+for key in ("Versions","DeleteMarkers"):
+    out=subprocess.run(["aws","s3api","list-object-versions","--bucket",b,
+        "--query",f"{key}[].{{Key:Key,VersionId:VersionId}}","--output","json"],
+        capture_output=True,text=True).stdout or "[]"
+    items=json.loads(out) or []
+    for i in range(0,len(items),900):
+        batch={"Objects":items[i:i+900],"Quiet":True}
+        subprocess.run(["aws","s3api","delete-objects","--bucket",b,
+            "--delete",json.dumps(batch)],capture_output=True)
+PY
+  t aws s3api delete-bucket --bucket "$b"
+done
+
+# ---- table / ecr ----
+[ -n "${TABLE:-}" ] && t aws dynamodb delete-table --table-name "$TABLE"
+for r in "${KERNEL_REPOS[@]}"; do
+  t aws ecr delete-repository --repository-name "agent-platform${SUFFIX}/$r" --force
+done
+
+# ---- secrets ----
+for s in "${LLM_SECRET:-}" "${ENTRY_SECRET:-}"; do
+  [ -n "$s" ] && t aws secretsmanager delete-secret --secret-id "$s" --force-delete-without-recovery
+done
+
+# ---- IAM (inline policies must go first) ----
+for r in "agent-platform-interactive-role${SUFFIX}" "agent-platform-sdk-role${SUFFIX}" \
+         "agent-platform-mcp-tools-role${SUFFIX}" "agent-platform-workspace-access${SUFFIX}" \
+         "agent-platform-backend-task${SUFFIX}" "agent-platform-backend-exec${SUFFIX}" \
+         "agent-platform-schedule-runner${SUFFIX}" "agent-platform-scheduler${SUFFIX}"; do
+  for p in $(aws iam list-role-policies --role-name "$r" --query 'PolicyNames[]' --output text 2>/dev/null); do
+    t aws iam delete-role-policy --role-name "$r" --policy-name "$p"
+  done
+  t aws iam delete-role --role-name "$r"
+done
+
+# ---- network (NAT release is slow; the EIP cannot detach until it is gone) ----
+[ -n "${NAT_ID:-}" ] && {
+  t aws ec2 delete-nat-gateway --nat-gateway-id "$NAT_ID"
+  log "waiting for nat to delete…"
+  aws ec2 wait nat-gateway-deleted --nat-gateway-ids "$NAT_ID" 2>/dev/null || true
+}
+[ -n "${EIP_ALLOC:-}" ] && t aws ec2 release-address --allocation-id "$EIP_ALLOC"
+[ -n "${IGW_ID:-}" ] && [ -n "${VPC_ID:-}" ] && {
+  t aws ec2 detach-internet-gateway --internet-gateway-id "$IGW_ID" --vpc-id "$VPC_ID"
+  t aws ec2 delete-internet-gateway --internet-gateway-id "$IGW_ID"
+}
+for s in $(echo "${PUBLIC_SUBNETS:-},${PRIVATE_SUBNETS:-}" | tr ',' ' '); do
+  [ -n "$s" ] && t aws ec2 delete-subnet --subnet-id "$s"
+done
+for rt in "${RT_PUB:-}" "${RT_PRIV:-}"; do
+  [ -n "$rt" ] && t aws ec2 delete-route-table --route-table-id "$rt"
+done
+for sg in "${ALB_SG:-}" "${SVC_SG:-}" "${RUNTIME_SG:-}"; do
+  [ -n "$sg" ] && t aws ec2 delete-security-group --group-id "$sg"
+done
+[ -n "${VPC_ID:-}" ] && t aws ec2 delete-vpc --vpc-id "$VPC_ID"
+
+log "destroy pass complete — re-run once if anything reported 'in use'"

--- a/deploy-cli/tests/verify.sh
+++ b/deploy-cli/tests/verify.sh
@@ -1,0 +1,368 @@
+#!/bin/bash
+# Post-deployment verification for the CLI-deployed agent platform.
+#
+# Two layers:
+#   L1  infrastructure reconciliation — resources exist AND are configured as
+#       intended (read-only, no model spend)
+#   L2  functional smoke — a real sign-in, a real agent invocation, an
+#       interactive session, S3 persistence, governance
+#
+# Both layers include NEGATIVE assertions. That is deliberate: a misconfigured
+# origin-verify header or a wildcard CORS origin leaves every resource present
+# and correct-looking, so only a request that SHOULD fail proves the control is
+# actually on.
+#
+# Usage:
+#   export AWS_PROFILE=... AWS_REGION=...
+#   PORTAL_PASSWORD='...' bash tests/verify.sh            # L1 + L2
+#   LAYER=1 bash tests/verify.sh                          # L1 only (free)
+#
+# Exit codes are distinct so a wrapper can tell the cases apart:
+#   0  all checks passed
+#   1  one or more checks FAILED — the deployment has a problem
+#   2  could not run (missing state, no credentials, no portal password)
+set -uo pipefail
+# NB: deliberately no `set -e`. Half these checks probe for failure, so a
+# non-zero exit from curl/aws is data, not a reason to stop. Each check decides
+# pass/fail for itself; the summary sets the exit code.
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+. "$HERE/../lib/common.sh" 2>/dev/null || { echo "cannot load lib/common.sh"; exit 2; }
+load
+
+LAYER="${LAYER:-2}"
+PASS=0; FAIL=0; SKIP=0
+FAILED_NAMES=""
+
+ok()   { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); FAILED_NAMES="$FAILED_NAMES\n    - $1"; printf '  \033[31mFAIL\033[0m %s\n    %s\n' "$1" "${2:-}"; }
+skip() { SKIP=$((SKIP+1)); printf '  \033[33mSKIP\033[0m %s (%s)\n' "$1" "${2:-}"; }
+
+# check NAME EXPECTED ACTUAL
+check() {
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected '$2', got '$3'"; fi
+}
+# check_not NAME FORBIDDEN ACTUAL — the negative form
+check_not() {
+  if [ "$2" != "$3" ]; then ok "$1"; else bad "$1" "value must not be '$2'"; fi
+}
+# check_contains NAME NEEDLE HAYSTACK
+check_contains() {
+  case "$3" in *"$2"*) ok "$1";; *) bad "$1" "'$2' not found in: $(printf '%s' "$3" | head -c 160)";; esac
+}
+
+# ---------------------------------------------------------------- preflight
+printf '\n=== preflight ===\n'
+[ -s "$STATE_FILE" ] || { echo "no state at $STATE_FILE — deploy first"; exit 2; }
+aws sts get-caller-identity >/dev/null 2>&1 || { echo "AWS credentials not usable"; exit 2; }
+: "${DIST_DOMAIN:?state has no DIST_DOMAIN — deployment incomplete}"
+PORTAL="https://$DIST_DOMAIN"
+echo "  stack:  $NAME"
+echo "  portal: $PORTAL"
+
+##############################################################################
+printf '\n=== L1 · network ===\n'
+##############################################################################
+VPC_STATE="$(aws ec2 describe-vpcs --vpc-ids "$VPC_ID" --query 'Vpcs[0].State' --output text 2>/dev/null)"
+check "vpc available" available "$VPC_STATE"
+
+DNS_H="$(aws ec2 describe-vpc-attribute --vpc-id "$VPC_ID" --attribute enableDnsHostnames \
+  --query 'EnableDnsHostnames.Value' --output text 2>/dev/null)"
+# Without DNS hostnames the runtimes cannot resolve the endpoints they call.
+check "vpc dns hostnames enabled" True "$DNS_H"
+
+SUBNET_COUNT="$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC_ID" \
+  --query 'length(Subnets)' --output text 2>/dev/null)"
+check "4 subnets" 4 "$SUBNET_COUNT"
+
+NAT_STATE="$(aws ec2 describe-nat-gateways --nat-gateway-ids "$NAT_ID" \
+  --query 'NatGateways[0].State' --output text 2>/dev/null)"
+check "nat gateway available" available "$NAT_STATE"
+
+# The private route table must actually point at the NAT, or every runtime call
+# out of the VPC silently fails.
+NAT_ROUTE="$(aws ec2 describe-route-tables --route-table-ids "$RT_PRIV" \
+  --query "RouteTables[0].Routes[?DestinationCidrBlock=='0.0.0.0/0'].NatGatewayId | [0]" --output text 2>/dev/null)"
+check "private subnets egress via nat" "$NAT_ID" "$NAT_ROUTE"
+
+##############################################################################
+printf '\n=== L1 · platform data ===\n'
+##############################################################################
+T_STATUS="$(aws dynamodb describe-table --table-name "$TABLE" --query 'Table.TableStatus' --output text 2>/dev/null)"
+check "dynamodb table active" ACTIVE "$T_STATUS"
+
+PITR="$(aws dynamodb describe-continuous-backups --table-name "$TABLE" \
+  --query 'ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus' --output text 2>/dev/null)"
+check "dynamodb PITR enabled" ENABLED "$PITR"
+
+VERS="$(aws s3api get-bucket-versioning --bucket "$WORKSPACE_BUCKET" --query Status --output text 2>/dev/null)"
+check "workspace bucket versioned" Enabled "$VERS"
+
+PAB="$(aws s3api get-public-access-block --bucket "$WORKSPACE_BUCKET" \
+  --query 'PublicAccessBlockConfiguration.BlockPublicAcls' --output text 2>/dev/null)"
+check "workspace bucket blocks public acls" True "$PAB"
+
+for r in "${KERNEL_REPOS[@]}"; do
+  SCAN="$(aws ecr describe-repositories --repository-names "agent-platform${SUFFIX}/$r" \
+    --query 'repositories[0].imageScanningConfiguration.scanOnPush' --output text 2>/dev/null)"
+  check "ecr scan-on-push: $r" True "$SCAN"
+  IMGS="$(aws ecr list-images --repository-name "agent-platform${SUFFIX}/$r" \
+    --query 'length(imageIds)' --output text 2>/dev/null)"
+  if [ "${IMGS:-0}" -ge 1 ] 2>/dev/null; then ok "ecr has an image: $r"; else bad "ecr has an image: $r" "0 images"; fi
+done
+
+##############################################################################
+printf '\n=== L1 · runtimes ===\n'
+##############################################################################
+for rt in claude_code_kernel agent_sdk_kernel mcp_tools_kernel; do
+  n="${rt}${RUNTIME_SUFFIX}"
+  ST="$(aws bedrock-agentcore-control list-agent-runtimes \
+    --query "agentRuntimes[?agentRuntimeName=='$n'].status | [0]" --output text 2>/dev/null)"
+  check "runtime READY: $n" READY "$ST"
+done
+
+# The interactive kernel must NOT be able to read workspaces/* with its own role —
+# that access is deliberately confined to the per-session credentials the backend
+# mints (docs/permissions.md). A policy that granted it would be a real finding.
+INT_POL="$(aws iam get-role-policy --role-name "agent-platform-interactive-role${SUFFIX}" \
+  --policy-name kernel --query 'PolicyDocument' --output json 2>/dev/null)"
+if printf '%s' "$INT_POL" | grep -q 'workspaces/\*'; then
+  bad "interactive role has no workspaces/* grant" "found a workspaces/* resource in the kernel policy"
+else
+  ok "interactive role has no workspaces/* grant"
+fi
+
+##############################################################################
+printf '\n=== L1 · portal edge (negative assertions) ===\n'
+##############################################################################
+ECS_RUN="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+  --query 'services[0].runningCount' --output text 2>/dev/null)"
+ECS_WANT="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+  --query 'services[0].desiredCount' --output text 2>/dev/null)"
+check "ecs tasks running == desired" "$ECS_WANT" "$ECS_RUN"
+
+CB="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+  --query 'services[0].deploymentConfiguration.deploymentCircuitBreaker.enable' --output text 2>/dev/null)"
+check "ecs deployment circuit breaker on" True "$CB"
+
+# CORS must be scoped, never "*": with allow_credentials the wildcard is
+# reflected back and defeats browser origin isolation.
+CORS_ENV="$(aws ecs describe-task-definition --task-definition "$TD_ARN" \
+  --query "taskDefinition.containerDefinitions[0].environment[?name=='PLATFORM_CORS_ORIGINS'].value | [0]" --output text 2>/dev/null)"
+check_not "backend CORS origin is not a wildcard" "*" "$CORS_ENV"
+check "backend CORS origin is the distribution" "$PORTAL" "$CORS_ENV"
+
+# The ALB must default-deny: its security group admits every CloudFront
+# distribution, so the origin-verify header is the only thing making the edge a
+# real chokepoint.
+ALB_DEFAULT="$(aws elbv2 describe-listeners --listener-arns "$L_ALB" \
+  --query 'Listeners[0].DefaultActions[0].Type' --output text 2>/dev/null)"
+check "alb listener default action is fixed-response" fixed-response "$ALB_DEFAULT"
+
+ALB_RULE_HDR="$(aws elbv2 describe-rules --listener-arn "$L_ALB" \
+  --query "Rules[?Priority=='100'].Conditions[0].HttpHeaderConfig.HttpHeaderName | [0]" --output text 2>/dev/null)"
+check "alb forwards only on x-origin-verify" x-origin-verify "$ALB_RULE_HDR"
+
+ALB_LOGS="$(aws elbv2 describe-load-balancer-attributes --load-balancer-arn "$ALB_ARN" \
+  --query "Attributes[?Key=='access_logs.s3.enabled'].Value | [0]" --output text 2>/dev/null)"
+check "alb access logs enabled" true "$ALB_LOGS"
+
+API_TYPE="$(aws apigateway get-rest-api --rest-api-id "$SERVICE_API_ID" \
+  --query 'endpointConfiguration.types[0]' --output text 2>/dev/null)"
+# A PUBLIC service entry would expose the SigV4 submit path to the internet.
+check "service-entry API is PRIVATE" PRIVATE "$API_TYPE"
+
+##############################################################################
+printf '\n=== L1 · reachability (negative assertions) ===\n'
+##############################################################################
+HEALTH_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$PORTAL/health" 2>/dev/null)"
+check "portal /health through cloudfront" 200 "$HEALTH_CODE"
+
+ANON_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$PORTAL/api/v1/kernels" 2>/dev/null)"
+# Unauthenticated API access must be refused.
+check "unauthenticated /api is 401" 401 "$ANON_CODE"
+
+FOREIGN_ACAO="$(curl -s -D - -o /dev/null --max-time 30 \
+  -H 'Origin: https://not-the-portal.invalid' "$PORTAL/api/v1/config" 2>/dev/null \
+  | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-origin"{print $2}')"
+if [ -z "$FOREIGN_ACAO" ]; then
+  ok "foreign Origin gets no Access-Control-Allow-Origin"
+else
+  bad "foreign Origin gets no Access-Control-Allow-Origin" "reflected: $FOREIGN_ACAO"
+fi
+
+# Direct-to-ALB must be refused. From outside the VPC the SG usually drops the
+# connection outright (timeout), which is also a pass — what must NOT happen is
+# a 200.
+# Being unable to reach the ALB is the EXPECTED outcome here, and curl signals
+# it with a non-zero exit (28 on timeout). Two things follow: `|| echo 000` would
+# concatenate onto the 000 curl already printed, and an unguarded assignment
+# aborts the whole run under `set -e`-style flags. So capture, then normalise.
+ALB_DIRECT="$(curl -s -o /dev/null -w '%{http_code}' --max-time 12 "http://$ALB_DNS/health" 2>/dev/null)" || true
+case "$ALB_DIRECT" in ''|*[!0-9]*) ALB_DIRECT=000 ;; esac
+case "$ALB_DIRECT" in
+  200) bad "direct ALB access is refused" "ALB answered 200 without the origin-verify header" ;;
+  403) ok  "direct ALB access is refused (403)" ;;
+  000) ok  "direct ALB access is refused (unreachable from here)" ;;
+  *)   ok  "direct ALB access is refused ($ALB_DIRECT)" ;;
+esac
+
+if [ "$LAYER" = "1" ]; then
+  printf '\n=== summary (L1 only) ===\n  passed %d   failed %d   skipped %d\n' "$PASS" "$FAIL" "$SKIP"
+  [ "$FAIL" -eq 0 ] || { printf '\n  failed checks:%b\n' "$FAILED_NAMES"; exit 1; }
+  exit 0
+fi
+
+##############################################################################
+printf '\n=== L2 · sign-in ===\n'
+##############################################################################
+if [ -z "${PORTAL_PASSWORD:-}" ]; then
+  echo "  PORTAL_PASSWORD not set — cannot exercise the API."
+  echo "  Set it to the password of the 'admin' Cognito user, or run LAYER=1."
+  exit 2
+fi
+
+TOKEN="$(aws cognito-idp initiate-auth --auth-flow USER_PASSWORD_AUTH \
+  --client-id "$CLIENT_ID" \
+  --auth-parameters "USERNAME=admin,PASSWORD=$PORTAL_PASSWORD" \
+  --query 'AuthenticationResult.IdToken' --output text 2>/dev/null || echo '')"
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "None" ]; then
+  echo "  could not sign in as 'admin' — wrong password, or the user has no permanent password"
+  exit 2
+fi
+ok "signed in as admin (id token acquired)"
+
+api() {  # method path [json-file]
+  local m="$1" p="$2" f="${3:-}"
+  if [ -n "$f" ]; then
+    curl -s -X "$m" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+      --data @"$f" --max-time 240 "$PORTAL$p" 2>/dev/null
+  else
+    curl -s -X "$m" -H "Authorization: Bearer $TOKEN" --max-time 240 "$PORTAL$p" 2>/dev/null
+  fi
+}
+# jq is not assumed; python3 stdlib does the parsing. errors="replace" matters
+# because agent output can carry control characters that break strict json.
+jget() {  # json-string  python-expression-on-d
+  python3 -c "
+import json,sys
+raw=sys.stdin.read()
+try: d=json.loads(raw)
+except Exception: print(''); sys.exit()
+try: print($1)
+except Exception: print('')"
+}
+
+ME="$(api GET /api/v1/me)"
+check "identity resolves to admin" admin "$(printf '%s' "$ME" | jget "d['user']")"
+check "admin has the admin role" True "$(printf '%s' "$ME" | jget "str(d['is_admin'])")"
+
+CFG="$(curl -s --max-time 30 "$PORTAL/api/v1/config" 2>/dev/null)"
+check "auth mode is cognito" cognito "$(printf '%s' "$CFG" | jget "d['auth_mode']")"
+
+##############################################################################
+printf '\n=== L2 · kernel catalog ===\n'
+##############################################################################
+KERNELS="$(api GET /api/v1/kernels)"
+check_contains "catalog lists the interactive kernel" '"claude-code"' "$KERNELS"
+check_contains "catalog lists the headless kernel" '"agent-sdk"' "$KERNELS"
+NOT_READY="$(printf '%s' "$KERNELS" | jget "','.join(k['id'] for k in d if k.get('status')!='READY')")"
+check "all catalogued kernels are READY" "" "$NOT_READY"
+
+##############################################################################
+printf '\n=== L2 · headless invocation (real model call) ===\n'
+##############################################################################
+MARKER="cli-verify-$$"
+cat > /tmp/verify-invoke.json <<JSON
+{"prompt":"Reply with exactly this token and nothing else: $MARKER","max_turns":2}
+JSON
+INV="$(api POST /api/v1/kernels/agent-sdk/invoke /tmp/verify-invoke.json)"
+INV_OK="$(printf '%s' "$INV" | jget "str(d.get('ok'))")"
+if [ "$INV_OK" = "True" ]; then
+  ok "headless kernel invocation succeeded"
+  RESULT="$(printf '%s' "$INV" | jget "d.get('result','')")"
+  check_contains "model echoed the request marker" "$MARKER" "$RESULT"
+  TURNS="$(printf '%s' "$INV" | jget "str((d.get('usage') or {}).get('num_turns',''))")"
+  if [ -n "$TURNS" ] && [ "$TURNS" != "None" ]; then ok "invocation reported usage (turns=$TURNS)"
+  else bad "invocation reported usage" "usage block empty"; fi
+else
+  # A quota rejection is a configuration state, not a broken deployment — say so
+  # rather than reporting a generic failure (this exact case produced a silent
+  # empty artifact during pipeline testing).
+  DETAIL="$(printf '%s' "$INV" | jget "d.get('detail') or d.get('error') or ''")"
+  case "$DETAIL" in
+    *"daily invocation limit"*) skip "headless kernel invocation" "daily quota reached: $DETAIL" ;;
+    *) bad "headless kernel invocation succeeded" "$(printf '%s' "$INV" | head -c 200)" ;;
+  esac
+fi
+
+##############################################################################
+printf '\n=== L2 · governance / observability ===\n'
+##############################################################################
+POLICY="$(api GET /api/v1/governance/policy)"
+LIMIT="$(printf '%s' "$POLICY" | jget "str(d.get('daily_limit_per_user',''))")"
+if [ -n "$LIMIT" ] && [ "$LIMIT" != "None" ]; then ok "governance policy readable (per-user limit $LIMIT)"
+else bad "governance policy readable" "no daily_limit_per_user in response"; fi
+
+USAGE="$(api GET /api/v1/governance/usage)"
+check_contains "usage counter readable" '"total"' "$USAGE"
+
+LEDGER="$(api "GET" "/api/v1/observability/invocations?limit=5")"
+# The invocation above must have been recorded — the ledger is how spend and
+# attribution are tracked.
+if printf '%s' "$LEDGER" | grep -q 'agent-sdk\|source'; then ok "invocation ledger has entries"
+else bad "invocation ledger has entries" "$(printf '%s' "$LEDGER" | head -c 160)"; fi
+
+##############################################################################
+printf '\n=== L2 · interactive session + workspace credentials ===\n'
+##############################################################################
+cat > /tmp/verify-session.json <<'JSON'
+{"name":"cli-verify","kernel":"claude-code"}
+JSON
+SESS="$(api POST /api/v1/sessions /tmp/verify-session.json)"
+SID="$(printf '%s' "$SESS" | jget "d.get('session_id','')")"
+if [ -z "$SID" ]; then
+  bad "interactive session created" "$(printf '%s' "$SESS" | head -c 200)"
+else
+  ok "interactive session created"
+  RSID="$(printf '%s' "$SESS" | jget "d.get('runtime_session_id','')")"
+
+  CONN="$(api GET "/api/v1/sessions/$SID/connect")"
+  WSS="$(printf '%s' "$CONN" | jget "d.get('wss_url','')")"
+  case "$WSS" in
+    wss://*) ok "connect minted a presigned wss url" ;;
+    *) bad "connect minted a presigned wss url" "$(printf '%s' "$CONN" | head -c 200)" ;;
+  esac
+
+  # connect() is also what mints the session-scoped S3 credentials and the
+  # refresh token; the lookup item proves that path ran end to end.
+  if [ -n "$RSID" ]; then
+    LOOKUP="$(aws dynamodb get-item --table-name "$TABLE" \
+      --key "{\"PK\":{\"S\":\"WSTOKEN\"},\"SK\":{\"S\":\"RSID#$RSID\"}}" \
+      --query 'Item.runtime_session_id.S' --output text 2>/dev/null || echo '')"
+    if [ "$LOOKUP" = "$RSID" ]; then ok "workspace refresh-token lookup item written"
+    else skip "workspace refresh-token lookup item written" "not found (older backend image writes it only to the session item)"; fi
+  fi
+
+  # cleanup: without this, repeated runs pile up sessions and burn daily quota
+  api DELETE "/api/v1/sessions/$SID" >/dev/null
+  ok "test session deleted (cleanup)"
+fi
+
+##############################################################################
+printf '\n=== L2 · ecosystem registry ===\n'
+##############################################################################
+MCP="$(api GET /api/v1/ecosystem/mcp-servers)"
+check_contains "registry seeded with built-in tools" 'code-interpreter' "$MCP"
+
+##############################################################################
+printf '\n=== summary ===\n'
+##############################################################################
+printf '  passed %d   failed %d   skipped %d\n' "$PASS" "$FAIL" "$SKIP"
+if [ "$FAIL" -ne 0 ]; then
+  printf '\n  failed checks:%b\n\n' "$FAILED_NAMES"
+  echo "  The deployment has a problem — see the notes in docs/DEPLOYMENT.md."
+  exit 1
+fi
+printf '\n  Deployment verified: infrastructure matches intent and the platform serves real traffic.\n'
+exit 0

--- a/deploy-cli/tests/verify.sh
+++ b/deploy-cli/tests/verify.sh
@@ -17,6 +17,11 @@
 #   PORTAL_PASSWORD='...' bash tests/verify.sh            # L1 + L2
 #   LAYER=1 bash tests/verify.sh                          # L1 only (free)
 #
+#   # Against a TERRAFORM deployment (no .state file needed): point TF_DIR at
+#   # the terraform/ directory and ids resolve from `terraform output` plus
+#   # the platform's fixed naming convention.
+#   TF_DIR=../../terraform LAYER=1 bash tests/verify.sh
+#
 # Exit codes are distinct so a wrapper can tell the cases apart:
 #   0  all checks passed
 #   1  one or more checks FAILED — the deployment has a problem
@@ -28,7 +33,46 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 . "$HERE/../lib/common.sh" 2>/dev/null || { echo "cannot load lib/common.sh"; exit 2; }
-load
+
+if [ -n "${TF_DIR:-}" ]; then
+  # ------------------------------------------------ terraform id source
+  # Resolve the same ids the CLI path records, from `terraform output` plus
+  # the platform's fixed naming convention (the suffix keeps both in step).
+  # This makes the suite the acceptance test for ANY deployment of the
+  # platform, not just one built by these scripts.
+  TFO="$(cd "$TF_DIR" && terraform output -json 2>/dev/null)" \
+    || { echo "terraform output failed in $TF_DIR"; exit 2; }
+  tfo() { printf '%s' "$TFO" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+v=d.get('$1',{}).get('value','')
+print(v if isinstance(v,str) else json.dumps(v))"; }
+
+  STATE_FILE=/dev/null          # skip the .state preflight
+  VPC_ID="$(tfo vpc_id)"
+  DIST_DOMAIN="$(tfo portal_url)"; DIST_DOMAIN="${DIST_DOMAIN#https://}"
+  TABLE="$(tfo table_name)"
+  WORKSPACE_BUCKET="$(tfo workspace_bucket_name)"
+  CLIENT_ID="$(tfo user_pool_client_id)"
+  SERVICE_API_ID="$(tfo service_entry_api_id)"
+  ALB_DNS="$(tfo alb_dns_name)"
+  # Fixed names (suffix-aware), then describe for the ARNs the checks need.
+  CLUSTER="agent-platform${SUFFIX}"
+  SERVICE="agent-platform-backend${SUFFIX}"
+  ALB_ARN="$(aws elbv2 describe-load-balancers --names "agent-platform-portal${SUFFIX}" \
+    --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null)"
+  L_ALB="$(aws elbv2 describe-listeners --load-balancer-arn "$ALB_ARN" \
+    --query 'Listeners[0].ListenerArn' --output text 2>/dev/null)"
+  TD_ARN="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" \
+    --query 'services[0].taskDefinition' --output text 2>/dev/null)"
+  # Network ids aren't outputs in reuse-mode deployments; resolve from the VPC.
+  NAT_ID="$(aws ec2 describe-nat-gateways --filter "Name=vpc-id,Values=$VPC_ID" "Name=state,Values=available" \
+    --query 'NatGateways[0].NatGatewayId' --output text 2>/dev/null)"
+  RT_PRIV="$(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=$VPC_ID" \
+    --query "RouteTables[?Routes[?NatGatewayId=='$NAT_ID']].RouteTableId | [0]" --output text 2>/dev/null)"
+else
+  load
+fi
 
 LAYER="${LAYER:-2}"
 PASS=0; FAIL=0; SKIP=0
@@ -53,7 +97,7 @@ check_contains() {
 
 # ---------------------------------------------------------------- preflight
 printf '\n=== preflight ===\n'
-[ -s "$STATE_FILE" ] || { echo "no state at $STATE_FILE — deploy first"; exit 2; }
+[ -n "${TF_DIR:-}" ] || [ -s "$STATE_FILE" ] || { echo "no state at $STATE_FILE — deploy first (or set TF_DIR)"; exit 2; }
 aws sts get-caller-identity >/dev/null 2>&1 || { echo "AWS credentials not usable"; exit 2; }
 : "${DIST_DOMAIN:?state has no DIST_DOMAIN — deployment incomplete}"
 PORTAL="https://$DIST_DOMAIN"
@@ -71,9 +115,13 @@ DNS_H="$(aws ec2 describe-vpc-attribute --vpc-id "$VPC_ID" --attribute enableDns
 # Without DNS hostnames the runtimes cannot resolve the endpoints they call.
 check "vpc dns hostnames enabled" True "$DNS_H"
 
+# At least 4 — a fresh VPC has exactly the platform's 2 public + 2 private,
+# but a reuse-mode deployment (existing_vpc_id) shares the VPC with other
+# subnets, and extras are not a defect.
 SUBNET_COUNT="$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC_ID" \
   --query 'length(Subnets)' --output text 2>/dev/null)"
-check "4 subnets" 4 "$SUBNET_COUNT"
+if [ "${SUBNET_COUNT:-0}" -ge 4 ] 2>/dev/null; then ok "subnets present ($SUBNET_COUNT >= 4)"
+else bad "subnets present" "expected >= 4, got '$SUBNET_COUNT'"; fi
 
 NAT_STATE="$(aws ec2 describe-nat-gateways --nat-gateway-ids "$NAT_ID" \
   --query 'NatGateways[0].State' --output text 2>/dev/null)"
@@ -159,8 +207,11 @@ ALB_DEFAULT="$(aws elbv2 describe-listeners --listener-arns "$L_ALB" \
   --query 'Listeners[0].DefaultActions[0].Type' --output text 2>/dev/null)"
 check "alb listener default action is fixed-response" fixed-response "$ALB_DEFAULT"
 
+# Find the forward rule by its header CONDITION, not by priority — the CLI
+# path creates it at 100, the terraform deployment at 1; the number is an
+# implementation detail, the header condition is the control being asserted.
 ALB_RULE_HDR="$(aws elbv2 describe-rules --listener-arn "$L_ALB" \
-  --query "Rules[?Priority=='100'].Conditions[0].HttpHeaderConfig.HttpHeaderName | [0]" --output text 2>/dev/null)"
+  --query "Rules[?Actions[?Type=='forward']].Conditions[].HttpHeaderConfig.HttpHeaderName | [0]" --output text 2>/dev/null)"
 check "alb forwards only on x-origin-verify" x-origin-verify "$ALB_RULE_HDR"
 
 ALB_LOGS="$(aws elbv2 describe-load-balancer-attributes --load-balancer-arn "$ALB_ARN" \

--- a/docs/deployment-aws-cli.md
+++ b/docs/deployment-aws-cli.md
@@ -9,8 +9,18 @@ The upstream sample ships CDK and Terraform. This runbook is for teams that
 cannot introduce either — a change-controlled account where every API call has to
 be auditable, an environment with no Terraform state backend, or a proof of
 concept that has to be readable end to end. It provisions the same four stacks
-(**network, platform, runtime, portal** — 98 resources) and reaches the same
-working portal.
+(**network, platform, runtime, portal** — 98 resources, tabulated with purpose
+and dependencies in [`resource-inventory.md`](resource-inventory.md)) and
+reaches the same working portal.
+
+**Scope: this is not the full possible footprint.** The optional
+`team_auth`/`team_demo` modules (enterprise-SSO demo, 43 more resources) and
+CloudFront standard logging v2 exist on the Terraform path and are deliberately
+not ported — details in [§6.6](#66-what-this-port-deliberately-leaves-out).
+The verification suite, on the other hand, is **not** CLI-only: pointed at the
+`terraform/` directory (`TF_DIR=... bash tests/verify.sh`) it runs the same 50
+checks against a Terraform deployment, including one adapted to an in-house
+standard.
 
 **Time:** ~35 minutes of wall clock for a cold deployment, most of it waiting on
 NAT, VPC Link and CloudFront.
@@ -298,6 +308,11 @@ LAYER=1 bash tests/verify.sh
 # L1 + L2 — adds a real sign-in, a real model call and an interactive session
 #            ~3 minutes, roughly $0.15 of model spend
 PORTAL_PASSWORD='ChangeMe-12+chars' bash tests/verify.sh
+
+# Against a TERRAFORM deployment (no .state file): ids resolve from
+# `terraform output` + the fixed naming convention. Same 50 checks — this is
+# the acceptance test for any deployment of the platform, however built.
+TF_DIR=../../terraform LAYER=1 bash tests/verify.sh
 ```
 
 **L1 — infrastructure reconciliation.** Confirms the 98 resources exist *and are

--- a/docs/deployment-aws-cli.md
+++ b/docs/deployment-aws-cli.md
@@ -1,0 +1,485 @@
+# Deploying the Agent Platform with the AWS CLI
+
+A step-by-step runbook for standing up
+[sample-agent-platform-with-agentcore](https://github.com/aws-samples/sample-agent-platform-with-agentcore)
+using nothing but the AWS CLI, plus a verification suite to confirm the result
+actually works.
+
+The upstream sample ships CDK and Terraform. This runbook is for teams that
+cannot introduce either — a change-controlled account where every API call has to
+be auditable, an environment with no Terraform state backend, or a proof of
+concept that has to be readable end to end. It provisions the same four stacks
+(**network, platform, runtime, portal** — 98 resources) and reaches the same
+working portal.
+
+**Time:** ~35 minutes of wall clock for a cold deployment, most of it waiting on
+NAT, VPC Link and CloudFront.
+**Standing cost:** roughly \$80–110/month at idle — the NAT Gateway (~\$32),
+the ALB and NLB (~\$16 each), two Fargate tasks (~\$25), plus per-request
+CloudFront and per-invocation model spend.
+
+---
+
+## 1. Prerequisites
+
+### 1.1 Tooling
+
+| Tool | Version | Notes |
+|---|---|---|
+| AWS CLI | v2 (≥ 2.15) | `aws --version` |
+| Python 3 | ≥ 3.9 | standard library only |
+| `bash` | 3.2 or newer | the scripts are 3.2-safe, so stock macOS works |
+| `zip` | any | packages the placeholder Lambda |
+| Docker with `buildx` | any recent | **must build `linux/arm64`** |
+| Node.js + npm | ≥ 20 | builds the frontend bundle |
+
+> **The ARM64 requirement is not negotiable.** AgentCore Runtime executes arm64
+> images only. On an x86 host, either enable QEMU emulation
+> (`docker run --privileged --rm tonistiigi/binfmt --install arm64`) or build on
+> a Graviton instance. An amd64 image is accepted at push time and then fails at
+> runtime creation, which reads as a broken image reference.
+
+### 1.2 AWS account
+
+- Amazon Bedrock AgentCore available in your target region.
+- Bedrock model access enabled for the Claude models you intend to use.
+- Quota headroom for: 1 VPC, 1 Elastic IP, 1 NAT Gateway, 2 load balancers,
+  1 CloudFront distribution.
+
+### 1.3 Deployer permissions
+
+The scripts call 17 services. If you are scoping a deployment role, it needs
+create/read/update on:
+
+```
+ec2  iam  s3  dynamodb  ecr  secretsmanager
+ecs  elbv2  cloudfront  cognito-idp  apigateway
+lambda  scheduler  sqs  logs  bedrock-agentcore-control
+sts
+```
+
+`iam:CreateRole`, `iam:PutRolePolicy` and `iam:PassRole` are required — the
+platform creates eight execution roles. Review what they grant in the upstream
+[`docs/permissions.md`](https://github.com/aws-samples/sample-agent-platform-with-agentcore/blob/main/docs/permissions.md)
+before approving.
+
+### 1.4 One account-level prerequisite
+
+API Gateway will not write access logs until the **account** has a CloudWatch
+role configured. This is account-wide, one-time, and idempotent — no CLI or IaC
+tool can set it per-stack:
+
+```bash
+aws apigateway get-account --query cloudwatchRoleArn --output text
+```
+
+If that prints `None`, create the role and point the account at it:
+
+```bash
+cat > /tmp/apigw-trust.json <<'JSON'
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+ "Principal":{"Service":"apigateway.amazonaws.com"},"Action":"sts:AssumeRole"}]}
+JSON
+
+ROLE_ARN=$(aws iam create-role --role-name apigateway-cloudwatch-logs-role \
+  --assume-role-policy-document file:///tmp/apigw-trust.json \
+  --query 'Role.Arn' --output text)
+
+aws iam attach-role-policy --role-name apigateway-cloudwatch-logs-role \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+
+aws apigateway update-account \
+  --patch-operations op=replace,path=/cloudwatchRoleArn,value="$ROLE_ARN"
+```
+
+Skipping this is not fatal: the deployment continues and warns, but the
+service-entry API has no access log.
+
+---
+
+## 2. Configure
+
+```bash
+git clone https://github.com/aws-samples/sample-agent-platform-with-agentcore.git
+cd sample-agent-platform-with-agentcore/deploy-cli
+
+export AWS_PROFILE=your-profile        # or rely on an instance/SSO role
+export AWS_REGION=us-west-2            # a region with AgentCore
+aws sts get-caller-identity            # confirm the account before proceeding
+```
+
+Everything else is set in `lib/common.sh`. The knobs you may want to change:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SUFFIX` | *(empty)* | appended to every resource name; set it to run a second stack alongside a CDK/Terraform one in the same account |
+| `VPC_CIDR` | `10.20.0.0/16` | must not overlap anything you plan to peer with |
+| `IMAGE_TAG` | `latest` | the tag the runtimes and ECS pull |
+| `ANTHROPIC_MODEL` | Sonnet 4.5 profile | baked into the kernels as the default |
+| `STATE_DIR` | `./.state` | where resource ids are recorded — **see §6** |
+
+Leaving `SUFFIX` empty produces the same names the CDK and Terraform stacks use
+(`agent-platform`, `agent-platform-workspaces-<account>-<region>`), so **do not
+leave it empty if one of those is already deployed in this account and region** —
+the names collide. Set something like `SUFFIX=-cli` to coexist.
+
+Whatever you choose, keep it constant: the suffix is part of resource names,
+globally-unique bucket names and AgentCore runtime names, so changing it
+mid-deployment orphans everything already built. It also names the state file, so
+every command below picks it up from there.
+
+---
+
+## 3. Deploy
+
+Run the phases in order. Every script is idempotent — safe to re-run after a
+failure, and a re-run reports `exists` rather than creating duplicates.
+
+### Phase 1 — network (~3 min)
+
+```bash
+bash scripts/10-network.sh
+```
+
+VPC, two public /24 and two private /20 subnets across two AZs, internet
+gateway, a NAT Gateway with a **fixed Elastic IP**, and an egress-only security
+group for the runtime ENIs.
+
+Note the NAT EIP in the output. All runtime egress leaves from that address, so
+it is what you allow-list on an external LLM gateway or corporate firewall.
+
+### Phase 2 — platform (~2 min)
+
+```bash
+bash scripts/20-platform.sh
+```
+
+Workspace bucket (versioned, encrypted, TLS-only), access-log bucket (90-day
+expiry), frontend bucket, DynamoDB table (PITR + SSE), four ECR repositories
+(scan-on-push), and the LLM-gateway secret placeholder.
+
+### Phase 3 — build and push images (~10 min)
+
+The runtimes cannot be created before the images exist: **AgentCore validates
+image access with the execution role at create time.**
+
+```bash
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+REGISTRY="$ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
+PREFIX="agent-platform${SUFFIX:-}"   # must match SUFFIX exactly
+
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$REGISTRY"
+
+cd ..
+for pair in \
+  "claude-code-kernel:runtimes/claude-code-kernel" \
+  "agent-sdk-kernel:runtimes/agent-sdk-kernel" \
+  "mcp-tools-kernel:runtimes/mcp-tools-kernel" \
+  "backend:backend"; do
+  name="${pair%%:*}"; dir="${pair##*:}"
+  docker buildx build --platform linux/arm64 \
+    -t "$REGISTRY/$PREFIX/$name:latest" --push "$dir"
+done
+cd -
+```
+
+### Phase 4 — runtimes (~4 min)
+
+```bash
+bash scripts/30-runtime.sh
+```
+
+Creates the three per-kernel execution roles (each holding only what its own
+code calls), the workspace-access role, and the three AgentCore runtimes. Waits
+for all three to reach `READY`.
+
+The script sleeps 20 seconds between attaching the inline policies and creating
+the runtimes. That wait is load-bearing — see §6.
+
+### Phase 5 — portal (~8 min)
+
+```bash
+bash scripts/40-portal-base.sh     # Cognito, SGs, ALB + internal NLB, listeners
+bash scripts/50-portal-app.sh      # ECS/Lambda/Scheduler IAM, DLQ, secrets, runner
+bash scripts/60-cloudfront-ecs.sh  # OAC, SPA function, distribution, ECS service
+bash scripts/70-service-entry.sh   # VPC Link, private REST API, stage
+```
+
+`60-` must run after `40-`: the backend's CORS origin is the CloudFront domain,
+which does not exist until the distribution does.
+
+Or run everything at once (image push still has to happen between phases 2 and 4):
+
+```bash
+bash scripts/00-deploy-all.sh
+```
+
+### Phase 6 — frontend (~2 min)
+
+```bash
+. .state/agent-platform${SUFFIX:-}.env    # loads FRONTEND_BUCKET, DIST_ID
+
+cd ../frontend
+npm ci && npm run build
+
+aws s3 sync dist/assets/ "s3://$FRONTEND_BUCKET/assets/" --delete \
+  --cache-control "public, max-age=31536000, immutable"
+aws s3 sync dist/ "s3://$FRONTEND_BUCKET/" --exclude "assets/*" --delete \
+  --cache-control "no-cache"
+aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths "/*"
+cd -
+```
+
+Hashed assets are immutable and cached hard; `index.html` must always be
+revalidated or browsers keep loading a stale bundle after a release.
+
+### Phase 7 — create the first user
+
+Self-signup is disabled by design.
+
+```bash
+. .state/agent-platform${SUFFIX:-}.env
+
+aws cognito-idp admin-create-user --user-pool-id "$POOL_ID" --username admin \
+  --user-attributes Name=email,Value=you@example.com Name=email_verified,Value=true \
+  --message-action SUPPRESS
+
+aws cognito-idp admin-set-user-password --user-pool-id "$POOL_ID" \
+  --username admin --password 'ChangeMe-12+chars' --permanent
+```
+
+`--permanent` matters: the sample login page does not implement the
+`NEW_PASSWORD_REQUIRED` challenge. To grant the admin surface to another user:
+
+```bash
+aws cognito-idp admin-add-user-to-group --user-pool-id "$POOL_ID" \
+  --username alice --group-name platform-admin
+```
+
+### Optional — the schedule-runner Lambda
+
+Phase 5 creates the function with placeholder code that raises if invoked, the
+same split upstream uses. Scheduled invocations need the real package:
+
+```bash
+cd ..
+BUILD=$(mktemp -d)
+python3 -m pip install --quiet \
+  --platform manylinux2014_aarch64 --implementation cp --python-version 3.13 \
+  --only-binary=:all: --target "$BUILD" -r backend/requirements-lambda.txt
+cp -R backend/app "$BUILD/app"
+cp backend/lambda/index.py "$BUILD/index.py"
+(cd "$BUILD" && zip -qr /tmp/runner.zip .)
+
+. /path/to/deploy-cli/.state/agent-platform${SUFFIX:-}.env
+aws lambda update-function-code --function-name "$SCHEDULE_FN" \
+  --zip-file fileb:///tmp/runner.zip
+aws lambda wait function-updated --function-name "$SCHEDULE_FN"
+```
+
+Re-run it whenever backend service code changes.
+
+---
+
+## 4. Verify
+
+```bash
+. .state/agent-platform${SUFFIX:-}.env
+echo "$PORTAL_URL"
+```
+
+Open that URL and sign in. Then run the suite:
+
+```bash
+# L1 only — read-only, no model spend, ~30 seconds
+LAYER=1 bash tests/verify.sh
+
+# L1 + L2 — adds a real sign-in, a real model call and an interactive session
+#            ~3 minutes, roughly $0.15 of model spend
+PORTAL_PASSWORD='ChangeMe-12+chars' bash tests/verify.sh
+```
+
+**L1 — infrastructure reconciliation.** Confirms the 98 resources exist *and are
+configured as intended*: NAT egress route present, PITR on, bucket versioning
+on, ECR scan-on-push on, all three runtimes `READY`, ECS at desired count,
+circuit breaker enabled, service-entry API `PRIVATE`.
+
+**L2 — functional smoke.** Signs in against Cognito, reads the kernel catalog,
+**invokes the headless kernel with a unique marker and asserts the model echoed
+it back**, creates an interactive session and checks that `connect` mints a
+presigned `wss://` URL, reads governance policy/usage and the invocation ledger,
+then deletes what it created.
+
+Both layers include **negative** assertions, which is the part that earns its
+keep. A misconfigured deployment often leaves every resource present and
+plausible:
+
+- unauthenticated `/api` must return **401**
+- a foreign `Origin` must receive **no** `Access-Control-Allow-Origin`
+- the ALB must refuse a request that lacks the origin-verify header
+- the interactive kernel's role must **not** grant `workspaces/*`
+
+Exit codes are distinct so this can gate a pipeline:
+
+| Code | Meaning |
+|---|---|
+| `0` | all checks passed |
+| `1` | one or more checks failed — the deployment has a problem |
+| `2` | could not run — no state file, no credentials, or `PORTAL_PASSWORD` unset |
+
+The suite is written so a broken deployment is caught, not just an absent one.
+Verified by deleting the ALB's origin-verify rule: three checks failed
+immediately and the exit code went to 1. Re-running `40-portal-base.sh`
+restored it.
+
+A `SKIP` is information, not a failure — it means a check could not apply (a
+backend image predating a feature, or a daily quota already exhausted).
+
+---
+
+## 5. Teardown
+
+```bash
+CONFIRM=yes bash scripts/99-destroy.sh
+```
+
+Deliberately **not** a mirror of the deploy path. CloudFront must be disabled
+and fully deployed before it can be deleted (~5 minutes), target groups stay
+"in use" briefly after their load balancer goes, and a versioned bucket needs
+its object versions purged before the bucket will drop. Run it twice if anything
+reports `in use`.
+
+The NAT Gateway bills hourly whether or not anything is running — tear the stack
+down between evaluations.
+
+---
+
+## 6. Notes from building this — read before you debug
+
+Nine problems surfaced porting this from Terraform. They are recorded here
+because most produce a symptom that points somewhere other than the cause.
+
+### 6.1 Ordering and consistency
+
+**AgentCore validates image pull at runtime-create time, and IAM is eventually
+consistent.** If you create a runtime immediately after `put-role-policy`, it
+fails with an image-access error that looks exactly like a wrong image URI or a
+missing tag. Terraform expresses this as `depends_on` on the *policy*; here it
+is an explicit `sleep 20` in `30-runtime.sh`. If you see an image error, confirm
+the image really is in ECR before touching the URI — then wait and retry.
+
+`create-function` on Lambda hits the same race against role propagation;
+`50-portal-app.sh` retries once after 15 seconds.
+
+**Waits that cannot be skipped.** A route to a NAT Gateway that is still
+`pending` is rejected. A VPC Link takes several minutes and an API integration
+against a pending link fails. Both are polled explicitly.
+
+**Order is hand-written and strictly serial.** Terraform derives a dependency
+graph and parallelises; here the order *is* the list in `00-deploy-all.sh`.
+CloudFront before ECS (the CORS origin is the distribution domain), NAT before
+routes, VPC Link before integrations.
+
+### 6.2 State
+
+**There is no state file, so nothing is implicit.** `.state/<stack>.env` records
+every resource id, and it is the only thing connecting the phases. Consequences:
+
+- **Losing it orphans the stack.** Re-running then tries to create resources that
+  already exist and fails on the ones whose names are globally unique. Keep it —
+  commit it to a private repo, or hold it in S3.
+- **A derived value that is not saved is invisible to the next phase.** This bit
+  us once: `LOG_GROUP` was computed in phase 5 and referenced in phase 6, where
+  it was simply unbound. Anything a later phase needs must go through `save`.
+- **It is not a substitute for Terraform state.** There is no drift detection.
+  If someone changes a resource by hand, only the verification suite will tell
+  you — which is a large part of why it exists.
+
+### 6.3 CLI-specific traps
+
+**Most calls are not idempotent.** `create-route`,
+`associate-route-table`, `authorize-security-group-ingress`, `create-group` and
+`update-continuous-backups` all error on a second call rather than no-op. Every
+create in these scripts is a describe-then-create, or tolerates the failure.
+This is the single largest source of bulk in the scripts and exactly what
+Terraform provides for free.
+
+**Shorthand parameter syntax breaks on generated values.**
+`--request-parameters key=value,key=value` treats characters inside a random
+secret as part of the mapping expression: the error is
+`Invalid mapping expression specified` **with the secret echoed back into it**.
+`--patch-operations` likewise cannot carry a JSON access-log format string —
+the quotes are parsed as key/value separators. Both go through
+`file://…json` or `--cli-input-json` instead. If a CLI call rejects a value that
+looks obviously valid, suspect shorthand parsing first.
+
+**`describe-log-groups` returns an ARN API Gateway rejects.** The returned ARN
+carries a trailing `:*`; passing it to `update-stage` fails with
+`Invalid ARN specified in the request`. Strip the suffix. Stacked with the
+previous item, the symptom is "the stage will not create", which reads like the
+account-level `cloudwatchRoleArn` from §1.4 is missing — it may well be set
+already.
+
+**Regional bucket creation differs.** `create-bucket` in `us-east-1` must **not**
+be given a `LocationConstraint`; every other region must. Handled, but worth
+knowing if you extend the scripts.
+
+### 6.4 Shell portability
+
+**macOS ships bash 3.2 (2007).** `mapfile`, associative arrays and `${var^^}`
+do not exist there. The first version of `10-network.sh` used
+`mapfile -t AZS < <(...)` and died with `mapfile: command not found` on the most
+likely operator laptop. These scripts are 3.2-safe; keep them that way.
+
+**Helper functions that return a value must not log to stdout.** A `log` call
+inside a function whose result is captured with `$(...)` gets concatenated into
+the return value, producing ids like `created subnet …\nsubnet-0fb…` that the
+next call rejects as *malformed*. All progress output inside the `*_ensure`
+helpers goes to stderr. This class of bug cannot exist in Terraform.
+
+**Hand-pasting JSON is a mistake.** Building IAM policies by string-concatenating
+heredocs produced a document with newlines where commas belonged. A `json.load`
+assertion in `put_policy` caught it before IAM did; policy assembly now runs
+through Python. Validate any generated JSON before it goes over the wire.
+
+**Do not use `set -e` in the verification suite.** Half its checks probe for
+failure, and `curl` exits non-zero on the timeout that *is* the expected result
+of a direct-to-ALB probe. An unguarded assignment aborted the run mid-way and
+surfaced as curl's exit code 28 rather than a test result.
+
+### 6.5 Operational gotchas
+
+**The daily invocation quota is real and its failure mode is silent.** The
+platform defaults to 200 invocations per user per day. Past that, calls are
+rejected — and a caller that treats the rejection as "the model returned nothing"
+will produce an empty artifact rather than an error. If results go
+inexplicably empty, check the quota before anything else:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "$PORTAL_URL/api/v1/governance/usage"
+```
+
+**Repeated verification runs consume that quota.** L2 spends a handful of
+invocations per run. It cleans up the resources it creates, but the counter is
+daily and does not roll back.
+
+**The ALB is only a chokepoint because of one header.** Its security group admits
+the AWS-managed CloudFront origin-facing prefix list, which covers *every*
+CloudFront distribution — not just yours. The `x-origin-verify` header plus the
+default-deny listener is what makes the edge real. If you rebuild the listener,
+rebuild the rule; the L1 suite checks for exactly this.
+
+**Two generated secrets live in plain text.** The service-entry shared header and
+the origin-verify value are stored in `.state/` and in the API Gateway
+integration config. Treat the state directory as sensitive and keep it out of
+public version control.
+
+### 6.6 What this port deliberately leaves out
+
+- **`team_auth` / `team_demo`** (28 resources): the optional enterprise-SSO
+  demo, disabled by default upstream.
+- **CloudFront standard logging v2**: needs a delivery source, destination and
+  delivery, with the destination in `us-east-1`. ALB and API Gateway access logs
+  *are* configured.
+- **A WAF web ACL**: managed rules bill per request; that is an adopter decision.


### PR DESCRIPTION
Carries #11 (all commits preserved, author attribution intact) plus the adjustments from #10 applied on top so it can land:

- **`tests/verify.sh` accepts `TF_DIR=<terraform dir>`**: every id resolves from `terraform output -json` + the fixed naming convention, no `.state` file — the 50 checks are now the acceptance test for any deployment of the platform, however built. **Verified against a live Terraform deployment: 33/33 L1 checks pass.**
- ALB origin-verify rule found by its header **condition**, not `Priority=='100'` (the Terraform deployment creates it at priority 1).
- `4 subnets` → `>= 4` (reuse-mode deployments share the VPC; extras aren't a defect).
- Scope gaps (team_auth/team_demo, CloudFront logging v2) stated at the top of the doc, with a pointer to `docs/resource-inventory.md` (#13) for the full 98-resource table.
- State-dir default is repo-relative.

The deployment scripts themselves are as verified in #11: a second environment stood up alongside the Terraform one, 50 passed / 0 failed, and the suite confirmed to fail when it should.

Closes #11
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)