### PR TITLE
deploy-cli: create the ECS service-linked role; brace the image tag for zsh

### DIFF
--- a/deploy-cli/scripts/60-cloudfront-ecs.sh
+++ b/deploy-cli/scripts/60-cloudfront-ecs.sh
@@ -140,6 +140,19 @@ aws s3api put-bucket-policy --bucket "$FRONTEND_BUCKET" --policy file:///tmp/fe-
 log "frontend bucket policy pinned to $DIST_ID"
 
 # ------------------------------------------------------------------ ECS
+# AWSServiceRoleForECS is account-global and CloudFormation creates it implicitly,
+# so the CDK and terraform paths never have to name it. On an account that has
+# never run ECS in any region, create-service below fails with "Unable to assume
+# the service linked role" instead. Needs iam:CreateServiceLinkedRole (§1.3).
+if ! aws iam get-role --role-name AWSServiceRoleForECS >/dev/null 2>&1; then
+  log "creating the ECS service-linked role (first ECS use in this account)"
+  aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com >/dev/null 2>&1 || true
+  # Creation is asynchronous: create-service keeps failing until ECS can assume it.
+  retry_until "the ECS service-linked role to exist" 12 5 \
+    aws iam get-role --role-name AWSServiceRoleForECS \
+    || die "AWSServiceRoleForECS is missing. Have an admin run: aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com"
+fi
+
 CLUSTER="agent-platform${SUFFIX}"
 aws ecs create-cluster --cluster-name "$CLUSTER" >/dev/null 2>&1 || true
 save CLUSTER "$CLUSTER"

--- a/docs/deployment-aws-cli.md
+++ b/docs/deployment-aws-cli.md
@@ -69,7 +69,9 @@ sts
 ```
 
 `iam:CreateRole`, `iam:PutRolePolicy` and `iam:PassRole` are required — the
-platform creates eight execution roles. Review what they grant in the upstream
+platform creates eight execution roles. `iam:CreateServiceLinkedRole` is also
+required on an account that has never used ECS; see §6.3. Review what they grant
+in the upstream
 [`docs/permissions.md`](https://github.com/aws-samples/sample-agent-platform-with-agentcore/blob/main/docs/permissions.md)
 before approving.
 
@@ -189,10 +191,13 @@ for pair in \
   "backend:backend"; do
   name="${pair%%:*}"; dir="${pair##*:}"
   docker buildx build --platform linux/arm64 \
-    -t "$REGISTRY/$PREFIX/$name:latest" --push "$dir"
+    -t "${REGISTRY}/${PREFIX}/${name}:latest" --push "$dir"
 done
 cd -
 ```
+
+The braces around `${name}` are load-bearing if you paste this into zsh — see
+§6.4.
 
 ### Phase 4 — runtimes (~4 min)
 
@@ -224,6 +229,12 @@ Or run everything at once (image push still has to happen between phases 2 and 4
 ```bash
 bash scripts/00-deploy-all.sh
 ```
+
+Every phase runs under `set -euo pipefail`, so a failure in any one of them ends
+the whole run: the phases after it never execute and the closing summary with the
+portal URL never prints. Read the last lines of output rather than the absence of
+a summary — fix the reported cause and re-run, which resumes rather than
+duplicates.
 
 ### Phase 6 — frontend (~2 min)
 
@@ -440,7 +451,27 @@ already.
 be given a `LocationConstraint`; every other region must. Handled, but worth
 knowing if you extend the scripts.
 
+**The ECS service-linked role is nobody's resource.** CloudFormation creates
+`AWSServiceRoleForECS` implicitly, so neither the CDK nor the Terraform path ever
+names it. Only a pure-CLI run on an account that has never used ECS **in any
+region** — the role is account-global — reaches `create-service` without it, and
+fails with `Unable to assume the service linked role`. `60-cloudfront-ecs.sh`
+creates it and waits, which is why the deployer needs
+`iam:CreateServiceLinkedRole`. The reason this went unnoticed for so long is that
+it self-heals: the rejected call triggers the role's creation asynchronously, so
+re-running the phase succeeds and the requirement stays invisible.
+
 ### 6.4 Shell portability
+
+**In zsh, an unbraced `$var:` eats the colon.** `:l` is a zsh parameter-expansion
+modifier meaning "lowercase", so `"$REGISTRY/$PREFIX/$name:latest"` expands to
+`…/mcp-tools-kernelatest` — the tag separator is gone. bash has no such modifier,
+so the same line is correct there. This matters only for blocks you paste into an
+interactive shell, which on macOS is zsh: the scripts themselves are `#!/bin/bash`
+and unaffected. The symptom points at the wrong phase — the push fails with
+`name unknown: The repository … does not exist`, which reads as a phase 2
+problem, when in fact the four repositories were created correctly and are simply
+empty. Brace every expansion followed by a literal colon.
 
 **macOS ships bash 3.2 (2007).** `mapfile`, associative arrays and `${var^^}`
 do not exist there. The first version of `10-network.sh` used


### PR DESCRIPTION
Fixes the two reports against the pure-CLI deployment path. Both were filed with the root cause and a proposed fix already worked out; thanks @Micheal-0116.

## #17 — ECS service-linked role

CloudFormation creates `AWSServiceRoleForECS` implicitly, so neither the CDK nor the Terraform path ever has to name it. Only a pure-CLI run on an account that has never used ECS **in any region** (the role is account-global) reaches `create-service` without it, and fails with `Unable to assume the service linked role`.

Because every script runs under `set -euo pipefail`, that aborts `00-deploy-all.sh`: `70-service-entry.sh` never runs and the closing summary with the portal URL never prints, so the failure reads as "deployment hung" rather than "deployment exited early".

`60-cloudfront-ecs.sh` now ensures the role the same way it ensures everything else in this port — look it up, create only if absent, then wait explicitly, since creation is asynchronous. If the deployer lacks `iam:CreateServiceLinkedRole` it now fails with a message you can act on instead of the opaque ECS error.

I did **not** add `|| true` to `create-service` as the issue optionally suggested. With the role handled up front the guard buys little, and swallowing that error is worse than the current behaviour: the run would report success with no service behind the load balancers, and phase 7 would happily build a service entry in front of nothing.

## #16 — unbraced `$name:latest`

In zsh, `:l` is a parameter-expansion modifier ("lowercase"), so `"$REGISTRY/$PREFIX/$name:latest"` loses its tag separator and expands to `…/<name>atest`. All four pushes then fail with `name unknown: The repository … does not exist`, which sends the reader back to phase 2 — but the repositories were created correctly and are simply empty. macOS operators hit this unconditionally, since the docs tell you to paste the block into a terminal and that terminal is zsh.

Braced. Verified on zsh 5.9 and bash that the new form produces the intended tag. A repo-wide scan found no other unbraced `$var:` in any markdown; the several occurrences inside the scripts are safe because those files are `#!/bin/bash`, which has no such modifier.

## Also

- §1.3 gains `iam:CreateServiceLinkedRole`, otherwise a tightly scoped deployment role fails on the new call.
- §6.3 and §6.4 document both traps, in each case leading with the misleading symptom. The ECS entry records why this went unnoticed: the rejected call triggers the role's creation asynchronously, so a bare retry succeeds and the requirement stays invisible.
- The `00-deploy-all.sh` section now says that a failed phase ends the whole run.

## Testing

`bash -n` passes. The service-linked-role branch was exercised against a stubbed `aws` in all three states — role present (block skipped), role created (waits, then continues), and creation denied (times out and exits with the actionable message).

It is **not** verified end to end on a fresh account: every account available to me has used ECS since 2022, so the new block is a no-op there. That is the same condition that kept this out of the docs in the first place. `tests/verify.sh` was not run; it needs a live deployment and L2 spends model budget, and neither change touches anything it asserts.

Closes #16
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)