### PR TITLE
Docs: locked-down VPC egress lessons + read-only network diag collector

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -395,6 +395,9 @@ headers.
 | `CREATE_FAILED` on runtime stack | Image tag not pushed to ECR yet — run `scripts/build-and-push.sh` first |
 | Runtime never becomes READY | Check `/aws/bedrock-agentcore/runtimes/*` CloudWatch logs; usually a container boot error |
 | First invoke very slow | Expected: cold start provisions a microVM and restores the S3 workspace |
+| Invoke fails with `RuntimeClientError: Runtime initialization time exceeded … 120s` | VPC-mode image pull is blocked: layers download from S3 (`prod-<region>-starport-layer-bucket`), so the runtime subnets need an S3 gateway-endpoint route **and** the runtime SG needs `443 → S3 prefix list` egress — outbound rules that only reference endpoint SGs silently drop it. The runtime showing READY proves nothing here: that's a control-plane check, the pull happens at session start. See permissions.md §10 |
+| Runtime log group has only zero-byte `otel-*`/`spans` streams, no `[start.sh]` lines | The container never started (see above), or `logs` egress from the runtime SG is blocked — fix logs first, stdout is the only window into `start.sh` |
+| Portal `connect` dies at the front door (408/504) and no session appears | Often a *derivative* of a container-init failure: warmup blocks on the cold start until whatever sits in front times out first. Reproduce with a direct CLI invoke (payload `{"action":"warmup"}`, `runtimeSessionId` ≥33 chars) to get the real error. Heuristic: a hang means network, an instant error means IAM |
 
 ## Teardown
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -424,3 +424,57 @@ demo's. Each is a small, local edit — the platform is built to be forked
 For anything that changes a role's scope, re-run `cdk synth --all` and diff the
 resulting `AWS::IAM::Policy` resources so the security team reviews the exact
 JSON that will be deployed.
+
+### Locked-down networking (VPC egress)
+
+The runtimes run in VPC mode ([§9](#9-data-and-network-boundaries)), so **all**
+container traffic — including the image pull at session cold start — is subject
+to your route tables, security groups, and any inspection layer in the path.
+Lessons from deploying into zero-trust enterprise VPCs:
+
+1. **Egress dependency matrix.** What each security group must be able to
+   reach on 443, per principal:
+
+   | Principal | Must reach | Why |
+   |---|---|---|
+   | Runtime SG (all kernels) | `ecr.api`, `ecr.dkr` | Image auth + manifest at session start |
+   | | **S3 via prefix list** — the regional ECR layer bucket (`prod-<region>-starport-layer-bucket`) and the workspace bucket | **Image layers live in S3, not in ECR** — the two ECR endpoints alone are not enough. Workspace restore/sync uses the same path |
+   | | `logs` | Container stdout → `/aws/bedrock-agentcore/runtimes/*` — your only window into `start.sh` |
+   | | `bedrock-runtime` (Bedrock mode) **or** the LLM gateway host + `secretsmanager` (gateway mode) | Model calls; the gateway key is read at container start |
+   | | `bedrock-agentcore` | MCP tools runtime (SigV4 proxy) and built-in tool sessions |
+   | | The portal domain (CloudFront) | The interactive kernel refreshes its per-session workspace credentials through the backend API |
+   | Backend SG (ECS task) | `dynamodb` + `s3` (prefix lists), `sts`, `bedrock-agentcore`, `bedrock-agentcore-control`, `logs` | Control plane, workspace-credential minting, and the warmup invoke |
+
+2. **Gateway endpoints match by prefix list — endpoint-SG-only egress
+   silently blocks them.** A zero-trust security group whose outbound rules
+   reference only interface-endpoint security groups drops every S3 and
+   DynamoDB packet, even when the gateway endpoint and its route exist.
+   Add explicit `443 → <prefix list>` egress rules, and put the *bucket*-level
+   restriction where it belongs: the gateway endpoint's policy (scope it to
+   the ECR layer bucket and the workspace bucket).
+
+3. **There is no service-managed S3 escape hatch anymore.** Agent runtimes
+   created after the May 2026 rollout have `requireServiceS3Endpoint`
+   permanently off — image-layer traffic is governed exclusively by your VPC
+   and the field cannot be re-enabled. Plan the S3 path from day one.
+
+4. **Control-plane validation is not a data-plane pull.** A runtime creating
+   successfully and showing `READY` only proves the execution role can read
+   the image metadata. The real layer download happens at *session* cold
+   start, through your VPC. The signature of a blocked pull is
+   `RuntimeClientError: Runtime initialization time exceeded … 120s` on
+   invoke, with an empty runtime log group.
+
+5. **Fully private variant.** Every hop above supports PrivateLink, including
+   the AgentCore data plane (`com.amazonaws.<region>.bedrock-agentcore`), so
+   the backend can run with no public egress at all. One exception: the
+   browser terminal connects to
+   `wss://bedrock-agentcore.<region>.amazonaws.com` directly from the user's
+   machine — corporate proxies must allow that domain *and* WebSocket
+   upgrade, and callers need
+   `bedrock-agentcore:InvokeAgentRuntimeWithWebSocketStream`.
+
+`scripts/collect-network-diag.sh` collects the full evidence set for this
+section (runtime network config, route tables, endpoints, SG rules, log
+groups, and a live warmup probe) read-only in one pass — useful when the
+diagnosis has to be run by someone else inside the locked-down account.

--- a/scripts/collect-network-diag.sh
+++ b/scripts/collect-network-diag.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Read-only network/permissions evidence collector for AgentCore runtimes in
+# VPC mode. Built for locked-down environments where the person running it is
+# not the person diagnosing it: every command is read-only, denied calls are
+# recorded and skipped (the denials themselves are useful evidence), and the
+# output is a single directory to tar up and send back.
+#
+# The one "write" is a pair of warmup probe invocations, which only create a
+# throwaway runtime session.
+#
+# Usage:
+#   scripts/collect-network-diag.sh <agent-runtime-id> [region]
+#   # e.g. scripts/collect-network-diag.sh claude_code_kernel-AbCdEf1234 ap-northeast-1
+#
+# What it collects (see docs/permissions.md §10 for how to read it):
+#   runtime network config / subnet AZ IDs / route tables / VPC endpoints /
+#   NAT / SG rules / runtime ENIs / ECS backend network+roles / runtime and
+#   backend log groups / two warmup probes (cold + retry) / caller-side
+#   endpoint reachability baseline.
+set -u
+
+RUNTIME_ID="${1:?usage: collect-network-diag.sh <agent-runtime-id> [region]}"
+REGION="${2:-$(aws configure get region 2>/dev/null || echo us-east-1)}"
+OUT="agentcore-diag-$(date +%Y%m%d-%H%M)"; mkdir -p "$OUT"
+exec > >(tee "$OUT/console.log") 2>&1
+run(){ echo; echo "########## $1 ##########"; shift; "$@" || echo "!! FAILED/DENIED (exit $?)"; }
+
+run "caller-identity" aws sts get-caller-identity
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null)
+RUNTIME_ARN="arn:aws:bedrock-agentcore:${REGION}:${ACCOUNT}:runtime/${RUNTIME_ID}"
+
+# ---- 1. Runtime definition: network mode / subnets / SG / env / status ----
+run "runtime-detail" aws bedrock-agentcore-control get-agent-runtime \
+  --agent-runtime-id "$RUNTIME_ID" --region "$REGION" --output json
+aws bedrock-agentcore-control get-agent-runtime --agent-runtime-id "$RUNTIME_ID" \
+  --region "$REGION" --output json > "$OUT/runtime.json" 2>/dev/null
+
+RT_SUBNETS=$(aws bedrock-agentcore-control get-agent-runtime --agent-runtime-id "$RUNTIME_ID" --region "$REGION" \
+  --query 'networkConfiguration.networkModeConfig.subnets' --output text 2>/dev/null)
+RT_SGS=$(aws bedrock-agentcore-control get-agent-runtime --agent-runtime-id "$RUNTIME_ID" --region "$REGION" \
+  --query 'networkConfiguration.networkModeConfig.securityGroups' --output text 2>/dev/null)
+
+# ---- 2. Topology: AZ IDs (check against the supported-AZ table!) /
+#         route tables / SG egress / VPC endpoints / NAT / flow logs ----
+if [ -n "$RT_SUBNETS" ]; then
+  run "runtime-subnets-az" aws ec2 describe-subnets --region "$REGION" --subnet-ids $RT_SUBNETS \
+    --query 'Subnets[].{id:SubnetId,azId:AvailabilityZoneId,cidr:CidrBlock,vpc:VpcId}' --output table
+  VPC_ID=$(aws ec2 describe-subnets --region "$REGION" --subnet-ids $RT_SUBNETS --query 'Subnets[0].VpcId' --output text)
+  run "all-route-tables" aws ec2 describe-route-tables --region "$REGION" --filters Name=vpc-id,Values="$VPC_ID" --output json
+  run "vpc-endpoints" aws ec2 describe-vpc-endpoints --region "$REGION" --filters Name=vpc-id,Values="$VPC_ID" \
+    --query 'VpcEndpoints[].{svc:ServiceName,type:VpcEndpointType,state:State,sgs:Groups[].GroupId,subnets:SubnetIds}' --output json
+  run "nat-gateways" aws ec2 describe-nat-gateways --region "$REGION" --filter Name=vpc-id,Values="$VPC_ID" --output json
+  run "flow-logs-enabled" aws ec2 describe-flow-logs --region "$REGION" --filter Name=resource-id,Values="$VPC_ID" --output json
+fi
+[ -n "$RT_SGS" ] && run "runtime-sg-rules" aws ec2 describe-security-groups --region "$REGION" --group-ids $RT_SGS --output json
+[ -n "$RT_SGS" ] && run "runtime-enis" aws ec2 describe-network-interfaces --region "$REGION" \
+  --filters Name=group-id,Values=$RT_SGS \
+  --query 'NetworkInterfaces[].{id:NetworkInterfaceId,subnet:SubnetId,ip:PrivateIpAddress,status:Status,desc:Description}' --output table
+
+# ---- 3. Backend ECS: subnets / SG / roles / whether ECS exec is available ----
+CLUSTER=$(aws ecs list-clusters --region "$REGION" --query 'clusterArns[?contains(@,`agent-platform`)]|[0]' --output text 2>/dev/null)
+if [ -n "$CLUSTER" ] && [ "$CLUSTER" != "None" ]; then
+  SVCS=$(aws ecs list-services --region "$REGION" --cluster "$CLUSTER" --query 'serviceArns' --output text 2>/dev/null)
+  if [ -n "$SVCS" ]; then
+    run "ecs-services-network" aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" --services $SVCS \
+      --query 'services[].{name:serviceName,taskdef:taskDefinition,execEnabled:enableExecuteCommand,net:networkConfiguration.awsvpcConfiguration}' --output json
+    for TD in $(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" --services $SVCS --query 'services[].taskDefinition' --output text); do
+      run "taskdef-roles $TD" aws ecs describe-task-definition --region "$REGION" --task-definition "$TD" \
+        --query 'taskDefinition.{taskRole:taskRoleArn,execRole:executionRoleArn,env:containerDefinitions[0].environment}' --output json
+    done
+  fi
+fi
+
+# ---- 4. Logs: has the container ever started + any backend warmup failures ----
+SINCE=$(( ($(date +%s) - 259200) * 1000 ))   # last 3 days
+run "agentcore-log-groups" aws logs describe-log-groups --region "$REGION" \
+  --log-group-name-prefix /aws/bedrock-agentcore --query 'logGroups[].logGroupName' --output table
+RLG="/aws/bedrock-agentcore/runtimes/${RUNTIME_ID}-DEFAULT"
+run "runtime-log-streams" aws logs describe-log-streams --region "$REGION" --log-group-name "$RLG" \
+  --order-by LastEventTime --descending --max-items 10 --output json
+run "runtime-recent-logs" aws logs filter-log-events --region "$REGION" --log-group-name "$RLG" \
+  --start-time "$SINCE" --max-items 300 --query 'events[].message' --output text
+BLG=$(aws logs describe-log-groups --region "$REGION" --log-group-name-prefix /ecs/agent-platform \
+  --query 'logGroups[0].logGroupName' --output text 2>/dev/null)
+if [ -n "$BLG" ] && [ "$BLG" != "None" ]; then
+  run "backend-warmup-failures" aws logs filter-log-events --region "$REGION" --log-group-name "$BLG" \
+    --filter-pattern '"warmup failed"' --start-time "$SINCE" --query 'events[].message' --output text
+  run "backend-recent-errors" aws logs filter-log-events --region "$REGION" --log-group-name "$BLG" \
+    --filter-pattern '?ERROR ?Timeout ?timed' --start-time "$SINCE" --max-items 100 --query 'events[].message' --output text
+fi
+
+# ---- 5. Warmup probes: cold start, then the same session again 3 min later.
+#         A cold failure + warm success just means slow start; two failures
+#         with "initialization time exceeded" points at the image-pull path. ----
+SID="diag-$(openssl rand -hex 16)"   # 37 chars, satisfies the >=33-char session-id minimum
+echo; echo "########## warmup-invoke-1 (session $SID) ##########"
+time aws bedrock-agentcore invoke-agent-runtime --region "$REGION" \
+  --agent-runtime-arn "$RUNTIME_ARN" --qualifier DEFAULT \
+  --runtime-session-id "$SID" \
+  --payload '{"action":"warmup"}' --cli-binary-format raw-in-base64-out \
+  --cli-read-timeout 300 --cli-connect-timeout 20 \
+  "$OUT/warmup-1.json"; echo "exit=$?"
+echo "(sleeping 180s, then retrying the same session…)"
+sleep 180
+echo; echo "########## warmup-invoke-2 (same session) ##########"
+time aws bedrock-agentcore invoke-agent-runtime --region "$REGION" \
+  --agent-runtime-arn "$RUNTIME_ARN" --qualifier DEFAULT \
+  --runtime-session-id "$SID" \
+  --payload '{"action":"warmup"}' --cli-binary-format raw-in-base64-out \
+  --cli-read-timeout 300 --cli-connect-timeout 20 \
+  "$OUT/warmup-2.json"; echo "exit=$?"
+cat "$OUT"/warmup-*.json 2>/dev/null
+
+# Pull runtime logs once more: [start.sh]/[startup] lines are the watershed —
+# none at all means the container never launched (image pull / logs egress).
+sleep 30
+run "runtime-logs-after-invoke" aws logs filter-log-events --region "$REGION" --log-group-name "$RLG" \
+  --start-time "$(( ($(date +%s) - 900) * 1000 ))" --max-items 300 --query 'events[].message' --output text
+
+# ---- 6. Caller-side reachability baseline. NOTE: this machine's egress path
+#         is usually NOT the VPC's — treat as a comparison point, not proof. ----
+for h in bedrock-agentcore.$REGION.amazonaws.com bedrock-agentcore-control.$REGION.amazonaws.com \
+         sts.$REGION.amazonaws.com secretsmanager.$REGION.amazonaws.com \
+         bedrock-runtime.$REGION.amazonaws.com logs.$REGION.amazonaws.com; do
+  echo; echo "########## curl $h ##########"
+  curl -sv --max-time 10 "https://$h/" -o /dev/null 2>&1 | grep -E 'Connected|HTTP/|timed out|Could not|SSL' || echo "!! no output"
+done
+
+echo; echo "Done. Package with: tar czf $OUT.tgz $OUT"


### PR DESCRIPTION
## What

Field lessons from deploying the platform into a zero-trust enterprise VPC (default-deny security groups, domain-allowlist firewall, no direct operator access):

- **`docs/permissions.md` §10** — new *Locked-down networking (VPC egress)* subsection: a per-principal egress dependency matrix (runtime SG / backend SG, Bedrock vs gateway mode), the gateway-endpoint gotcha (S3/DynamoDB match by **prefix list**, so endpoint-SG-only outbound rules silently drop them — and ECR image *layers* live in S3, not ECR), `requireServiceS3Endpoint` post-rollout semantics, why control-plane image validation is not a data-plane pull, and the fully-private PrivateLink variant incl. the WebSocket exception.
- **`docs/deployment.md`** — three new troubleshooting rows matching the failure signatures: `RuntimeClientError: Runtime initialization time exceeded … 120s`, a runtime log group with only zero-byte OTEL streams, and a front-door timeout on portal `connect` as a *derivative* symptom (with the hang-means-network / instant-error-means-IAM heuristic).
- **`scripts/collect-network-diag.sh`** — read-only, one-pass evidence collector (runtime network config, route tables, VPC endpoints, SG rules, log groups, live warmup probes, caller-side reachability baseline). Built for the case where the person running it is not the person diagnosing it; denied calls are recorded and skipped.

## Why

A blocked S3 path at session cold start reproducibly presents as a 120-second init timeout with zero container logs — nothing in the docs previously connected that signature to the image-layer/S3 dependency, and the diagnosis took a multi-day round-trip with a customer ops team. This PR turns that round-trip into a checklist plus one script run.

## Testing

- `bash -n` on the script; the same command sequence was exercised end-to-end (as a customer-run collector) during the deployment that produced these lessons.
- Docs-only otherwise; sanitization-scanned (no account IDs, resource IDs, or customer identifiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)