### PR TITLE
README: say where the gateway key lives, and bust the diagram cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,17 @@ It shows how a platform team can offer two hosting models behind one portal:
 Both kernels route model traffic through a configurable **LLM gateway**
 (e.g. LiteLLM) with a **fixed egress IP** (VPC mode + NAT Gateway), so the
 platform works in enterprises that enforce model allow-lists, budgets and
-source-IP restrictions. Direct Bedrock access (cross-region inference) is
-supported as an alternative.
+source-IP restrictions. The gateway key lives in a platform-side service and
+**never enters a session container** — a session's user is root in its own
+microVM, so a kernel gets a short-lived, per-session grant rather than a
+credential. Direct Bedrock access (cross-region inference) is supported as an
+alternative.
 
 ![portal overview](docs/images/portal-overview.png)
 
-![architecture](docs/images/architecture.svg)
+<!-- ?v= bumps the URL so GitHub's image cache serves the current diagram
+     instead of a stale copy at the same path. Bump it whenever the SVG changes. -->
+![architecture](docs/images/architecture.svg?v=2)
 
 ## What's inside
 


### PR DESCRIPTION
Follow-up to #20. Two small things that PR left behind.

**The intro prose lagged the diagram.** It described the gateway path in terms of egress IP and allow-lists without the property that actually matters now: the key is not in the container the session's user is root in. The diagram already showed the `llm-edge` hop; only the paragraph above it was stale.

**The diagram looked unchanged on the repo homepage.** `docs/images/architecture.svg` on `main` is the new render — verified straight from raw:

```
$ curl -sI .../main/docs/images/architecture.svg   # 200, 78924 bytes, contains llm-edge
```

GitHub's image cache was still serving the previous render because the content changed at the same path, so the cache key never changed. Appending `?v=2` gives it a new one. Both URL forms GitHub rewrites a relative image path to were checked with the query string present and serve the full file, so this does not risk breaking the embed. There is a comment next to it to bump the number on the next diagram change.

No behaviour change; docs only.