### PR TITLE
Backend: one attempt per invoke, and tell the script why an agent failed

### DIFF
--- a/backend/app/services/kernel_service.py
+++ b/backend/app/services/kernel_service.py
@@ -25,10 +25,31 @@ class KernelService:
     def __init__(self) -> None:
         # Long read timeout: a single invocation can legitimately run for
         # minutes (agent loop + built-in tool sessions like browser startup).
+        #
+        # Two things here are easy to get wrong.
+        #
+        # 1) `retries={"max_attempts": 1}` does not mean "do not retry". In
+        #    botocore's legacy retry mode that key counts *retries*, not total
+        #    attempts, so it resolves to {'total_max_attempts': 2} and one read
+        #    timeout costs two full timeouts back to back — visible as a single
+        #    span of twice the configured value. `total_max_attempts: 1` is what
+        #    actually expresses one attempt.
+        #
+        # 2) Timeouts are deliberately not retried (see _invoke() below). A
+        #    retry re-sends a call that already ran for minutes: it doubles the
+        #    spend and, when the cause is upstream slowness rather than a flake,
+        #    times out again anyway.
+        #
+        # The value itself is tuned against observed slowest *successes* with
+        # roughly a third of headroom on top. It is intentionally not generous:
+        # a larger ceiling turns every genuine hang into a longer stall. If you
+        # start seeing clusters of read timeouts all landing near this number,
+        # the fix is to raise it — upstream latency has moved — rather than to
+        # go looking for a fault on the model side.
         self.agentcore = boto3.client(
             "bedrock-agentcore",
             region_name=settings.aws_region,
-            config=Config(read_timeout=300, retries={"max_attempts": 1}),
+            config=Config(read_timeout=450, retries={"total_max_attempts": 1}),
         )
         self.control = boto3.client(
             "bedrock-agentcore-control", region_name=settings.aws_region

--- a/backend/app/services/pipeline_service.py
+++ b/backend/app/services/pipeline_service.py
@@ -356,8 +356,16 @@ class PipelineService:
     def _call_agent(self, sk: str, prompt: str, opts: dict, *, user: str, ref: str,
                     phase: str, tb, parent_span: str | None):
         """The agent() bridge: one governed invocation + a per-agent run record
-        + a trace span. Returns text, a parsed object (when a schema is given),
-        or None on failure — matching the Workflow tool's agent() contract."""
+        + a trace span.
+
+        Returns ``(value, error)``. ``value`` is text, a parsed object (when a
+        schema is given), or None on failure — matching the Workflow tool's
+        agent() contract, which the shim still honours for ``agent()``.
+        ``error`` is the precise reason ('' when ok) and exists because scripts
+        used to be unable to tell a model flake from a read timeout: both
+        surfaced as None, so retry logic had to guess from elapsed time.
+        2026-08-19 that guess re-sent 16 read-timeout calls in a fan-out phase
+        as if they were flake, and the amplification killed the run."""
         from app.services.agent_service import agent_service
         from app.services.governance_service import QuotaExceeded, SourceDisabled
         from app.services.invocation_service import invoke, invoke_async_and_wait
@@ -408,7 +416,7 @@ class PipelineService:
                                      "error": entry.get("error")},
                         error=not entry["ok"],
                     )
-                return value
+                return value, entry.get("error", "")
 
             eff_prompt = prompt
             if schema and target == "agent-sdk":
@@ -460,7 +468,7 @@ class PipelineService:
                 },
                 error=not entry["ok"],
             )
-        return value
+        return value, entry.get("error", "")
 
 
 pipeline_service = PipelineService()

--- a/backend/app/services/pipeline_service.py
+++ b/backend/app/services/pipeline_service.py
@@ -447,7 +447,17 @@ class PipelineService:
                         entry["error"] = f"schema mismatch: missing {[k for k in required if k not in value]}"
                         value = None
                     elif value is None:
-                        entry["error"] = "no JSON object in output"
+                        # Separate "there was no JSON" from "there was JSON and
+                        # it was broken". One message covered both, so an
+                        # unescaped quote wrecking a payload read as the model
+                        # not emitting JSON at all, and the search went the
+                        # wrong way for a while.
+                        entry["error"] = (
+                            "invalid JSON in output (found a {...} block but json.loads failed"
+                            " — typically unescaped quotes inside a string value)"
+                            if re.search(r"\{.*\}", text, re.DOTALL)
+                            else "no JSON object in output"
+                        )
                 else:
                     value = text
         except (QuotaExceeded, SourceDisabled) as e:

--- a/backend/app/services/pipeline_service.py
+++ b/backend/app/services/pipeline_service.py
@@ -37,6 +37,26 @@ MAX_SCRIPT = 100_000
 MAX_HISTORY = 10
 RESULT_CAP = 24_000
 
+# A nested pipeline (a script's workflow() call) runs inside its caller's wall
+# clock: the parent's kill timer keeps running while the child works, and the
+# child used to get its own full RUN_TIMEOUT_S on top. Unbounded, the child can
+# spend the entire parent budget — a parent has been killed at its 75-minute
+# ceiling with nothing to show because one child took 72 of those minutes.
+#
+# So a child is capped at "parent's remaining budget minus a reserve". Size the
+# reserve from what the parent still has to do after the call returns; the
+# default here covers a parent whose own remaining phases measured under 20
+# minutes, with room for that work to grow.
+#
+# Killing the child is much cheaper than killing the parent: workflow() throws,
+# so a script that can degrade — reusing the previous result and recording why
+# it is stale — still finishes and still produces its output.
+CHILD_RESERVE_S = 25 * 60
+# ...but never hand a child a budget so small it cannot finish anything; below
+# this, let it run and accept that the parent may die instead. Hitting this
+# floor means the parent was already almost out of time when it called out.
+CHILD_MIN_S = 10 * 60
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -249,27 +269,33 @@ class PipelineService:
 
     def run_sync(self, name: str, user: str = "scheduler", *, args=None,
                  source: str = "schedule", nested: bool = False,
-                 parent_run: str | None = None) -> dict:
+                 parent_run: str | None = None,
+                 timeout_s: int | None = None) -> dict:
         """Scheduler / nested-workflow path (in-backend): run to completion,
         return a summary. Nested runs (a script's ``workflow()`` call) cannot
-        nest further — one level, same as the platform contract."""
+        nest further — one level, same as the platform contract. ``timeout_s``
+        caps this run's wall clock below the engine default (see
+        CHILD_RESERVE_S)."""
         pipe = self.get_pipeline(name)
         if not pipe:
             raise ValueError(f"pipeline {name} not found")
         sk = self._create_run(name, user, source, parent_run=parent_run)
-        self._execute(sk, pipe, user, args, allow_nested=not nested)
+        self._execute(sk, pipe, user, args, allow_nested=not nested,
+                      timeout_s=timeout_s)
         run = self.get_run(sk.partition("#")[2]) or {}
         return {"ok": run.get("status") == "completed", "run_id": run.get("id"),
                 "result": _plain(run.get("result"))}
 
     # --------------------------------------------------------------- execute
 
-    def _execute(self, sk: str, pipe: dict, user: str, args, allow_nested: bool = True) -> None:
+    def _execute(self, sk: str, pipe: dict, user: str, args, allow_nested: bool = True,
+                 timeout_s: int | None = None) -> None:
         from app.services.trace_service import TraceBuilder
-        from app.services.workflow_engine import workflow_engine
+        from app.services.workflow_engine import RUN_TIMEOUT_S, workflow_engine
 
         run_id = sk.partition("#")[2]
         ref = f"piperun:{run_id}"
+        started = time.time()
         tb = TraceBuilder(pipe["name"])
         self._update_run(sk, trace_id=tb.trace_id)
 
@@ -288,13 +314,22 @@ class PipelineService:
             # script receives its {ok, run_id, result} summary. parent_run
             # lets the run list show the child under its caller instead of
             # as a sibling that looks independently scheduled.
+            #
+            # The child runs inside the parent's wall clock (the parent's kill
+            # timer keeps ticking while this blocks), so it gets what is left
+            # minus a reserve for the parent's own remaining work. Uncapped,
+            # a slow child takes the parent down mid-phase and the whole run
+            # produces nothing — see CHILD_RESERVE_S.
+            left = int((timeout_s or RUN_TIMEOUT_S) - (time.time() - started) - CHILD_RESERVE_S)
             return self.run_sync(child, user=user, args=child_args,
-                                 source=SOURCE, nested=True, parent_run=run_id)
+                                 source=SOURCE, nested=True, parent_run=run_id,
+                                 timeout_s=max(CHILD_MIN_S, left))
 
         try:
             out = workflow_engine.run(
                 script=pipe["script"], args=args, call_agent=call_agent, on_phase=on_phase, tb=tb,
                 run_workflow=run_workflow if allow_nested else None,
+                timeout_s=timeout_s,
             )
             result = out.get("result")
             if isinstance(result, (dict, list)):

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -96,7 +96,8 @@ class WorkflowEngine:
             run_workflow=None, timeout_s: int | None = None) -> dict:
         """Execute one script to completion (blocking; call from a thread).
 
-        ``call_agent(prompt, opts, phase, parent_span)`` is the injected bridge
+        ``call_agent(prompt, opts, phase, parent_span)`` returns
+        ``(value, error)`` and is the injected bridge
         to the governed invocation pipeline. ``run_workflow(name, args)``,
         when provided, serves the script's ``workflow()`` calls (one level of
         nesting — pipeline_service passes it for top-level runs only).
@@ -142,6 +143,15 @@ class WorkflowEngine:
                     # hour of guessing.
                     logger.warning("workflow reply dropped, script is gone: msg %s", msg_id)
 
+        log_lock = threading.Lock()
+
+        def add_log(text: str) -> None:
+            # called from both the reader loop (script log()) and the worker
+            # pool (agent failures), so the cap check needs the lock
+            with log_lock:
+                if len(logs) < LOG_CAP:
+                    logs.append(str(text)[:500])
+
         def touch_phase(now: float) -> dict | None:
             entry = phases.get(state["phase"])
             if entry:
@@ -152,12 +162,24 @@ class WorkflowEngine:
             t = msg.get("type")
             if t == "agent":
                 entry = phases.get(state["phase"])
-                value = call_agent(
-                    msg.get("prompt", ""), msg.get("opts") or {},
+                opts = msg.get("opts") or {}
+                value, err = call_agent(
+                    msg.get("prompt", ""), opts,
                     phase=state["phase"], parent_span=entry["id"] if entry else None,
                 )
                 touch_phase(time.time())
-                reply(msg["id"], value)
+                # Every failure states its own reason in the run log, next to
+                # the script's own lines. Before this the reason lived only in
+                # the run's agents[] array while the script logged whatever it
+                # assumed had happened: a gateway slowdown once had every one of
+                # seventeen read-timeout victims logging "no valid JSON", and
+                # finding the truth meant querying DynamoDB by hand.
+                if err:
+                    label = str(opts.get("label") or msg.get("prompt", "")[:30]).replace("\n", " ")
+                    add_log(f"agent failed · {label[:60]} · {state['phase'] or '-'}: {err}")
+                # wrapped so the shim can hand the script both, while keeping
+                # agent() itself returning value-or-null as the contract says
+                reply(msg["id"], {"__agent_reply": True, "value": value, "error": err or ""})
             elif t == "s3read":
                 reply(msg["id"], self._s3read(msg.get("key", "")))
             elif t == "s3write":
@@ -214,8 +236,7 @@ class WorkflowEngine:
                             phases[title] = {"id": TraceBuilder.new_id(), "start": time.time(), "end": None}
                         on_phase(title)
                     elif t == "log":
-                        if len(logs) < LOG_CAP:
-                            logs.append(str(msg.get("msg", ""))[:500])
+                        add_log(msg.get("msg", ""))
                     elif t == "done":
                         state["result"], state["done"] = msg.get("result"), True
                     elif t == "fatal":

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -93,13 +93,15 @@ class WorkflowEngine:
             return []
 
     def run(self, *, script: str, args=None, call_agent, on_phase, tb=None,
-            run_workflow=None) -> dict:
+            run_workflow=None, timeout_s: int | None = None) -> dict:
         """Execute one script to completion (blocking; call from a thread).
 
         ``call_agent(prompt, opts, phase, parent_span)`` is the injected bridge
         to the governed invocation pipeline. ``run_workflow(name, args)``,
         when provided, serves the script's ``workflow()`` calls (one level of
         nesting — pipeline_service passes it for top-level runs only).
+        ``timeout_s`` overrides ``RUN_TIMEOUT_S`` — pipeline_service uses it to
+        cap a nested run inside its caller's remaining budget.
         Returns ``{ok, result, error, logs}``.
         """
         node = shutil.which("node")
@@ -130,7 +132,15 @@ class WorkflowEngine:
                     proc.stdin.write(json.dumps({"id": msg_id, "value": value}, ensure_ascii=False) + "\n")
                     proc.stdin.flush()
                 except Exception:  # script exited mid-flight
-                    pass
+                    # Not silent: a dropped reply leaves the script awaiting a
+                    # promise nothing can resolve, so it sits there until the
+                    # kill timer. 2026-08-18 that made a timed-out run read as
+                    # "the agent succeeded, then the script froze" — the agent
+                    # record gets written by this worker thread, which outlives
+                    # the killed Node process, and then this write finds a dead
+                    # pipe. One log line is the difference between that and an
+                    # hour of guessing.
+                    logger.warning("workflow reply dropped, script is gone: msg %s", msg_id)
 
         def touch_phase(now: float) -> dict | None:
             entry = phases.get(state["phase"])
@@ -172,7 +182,19 @@ class WorkflowEngine:
             target=lambda: stderr_tail.extend(proc.stderr.read().splitlines()[-5:]), daemon=True
         ).start()
 
-        killer = threading.Timer(RUN_TIMEOUT_S, proc.kill)
+        budget_s = int(timeout_s or RUN_TIMEOUT_S)
+        # An explicit flag, not `killer.finished.is_set()`: Timer.cancel() sets
+        # that same Event, and cancel() runs unconditionally in the finally
+        # block below — so the old check was always true and every incomplete
+        # run got labelled "(timed out)", crashes included. 2026-08-18 that
+        # cost a chunk of a triage before the wall clock settled it.
+        timed_out = threading.Event()
+
+        def on_timeout() -> None:
+            timed_out.set()
+            proc.kill()
+
+        killer = threading.Timer(budget_s, on_timeout)
         killer.start()
         try:
             with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_FANOUT) as pool:
@@ -214,7 +236,10 @@ class WorkflowEngine:
             state["error"] = state["error"] or (
                 "script exited without completing"
                 + (f" — stderr: {' | '.join(stderr_tail)}" if stderr_tail else "")
-                + (" (timed out)" if killer.finished.is_set() else "")
+                # the budget is in the message on purpose: a nested run is
+                # capped below RUN_TIMEOUT_S, so "which ceiling did we hit"
+                # is not inferable from the constant
+                + (f" (timed out after {budget_s}s)" if timed_out.is_set() else "")
             )
         if tb is not None:
             for title, p in phases.items():

--- a/backend/app/workflow/runner.mjs
+++ b/backend/app/workflow/runner.mjs
@@ -11,10 +11,12 @@
 //                   {type:"phase", title} / {type:"log", msg}   (one-way)
 //                   {type:"done", result} / {type:"fatal", error}
 //   engine → shim : {id, value}
+//                   {id, value:{__agent_reply, value, error}}   (agent replies)
 //
 // Compatibility with the Claude Code Workflow tool: `export const meta`,
 // agent()/parallel()/pipeline()/phase()/log()/args/budget/workflow() all work
-// with the same shapes. Platform-specific: `opts.agent` targets a published
+// with the same shapes. Platform-specific: `agentDetailed()` returns
+// {value, error} instead of just the value, `opts.agent` targets a published
 // agent by name (otherwise the raw sdk kernel), `opts.async = {key, timeout_s}`
 // runs the agent as an AgentCore async task (long feeds), and
 // s3read()/s3write()/s3list() replace local filesystem access. workflow()
@@ -49,7 +51,19 @@ createInterface({ input: process.stdin }).on('line', (line) => {
   }
 })
 
-const hostAgent = (prompt, opts = {}) => rpc('agent', { prompt: String(prompt), opts })
+// The engine replies {__agent_reply, value, error}. agent() keeps the Workflow
+// tool's contract (the value, or null on failure); agentDetailed() also hands
+// back the reason, which is what retry logic needs to tell a model flake from
+// a read timeout — from a bare null the two are indistinguishable, and guessing
+// between them by elapsed time is what amplified the 2026-08-19 outage.
+// The unwrap tolerates a bare value so a stale engine still works.
+const hostAgentDetailed = async (prompt, opts = {}) => {
+  const r = await rpc('agent', { prompt: String(prompt), opts })
+  return (r && typeof r === 'object' && r.__agent_reply)
+    ? { value: r.value ?? null, error: String(r.error || '') }
+    : { value: r ?? null, error: '' }
+}
+const hostAgent = async (prompt, opts = {}) => (await hostAgentDetailed(prompt, opts)).value
 const hostS3read = (key) => rpc('s3read', { key: String(key) })
 const hostS3write = (key, body) => rpc('s3write', { key: String(key), body: String(body) })
 const hostS3list = (prefix) => rpc('s3list', { prefix: String(prefix) })
@@ -100,13 +114,14 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 // nosemgrep: javascript.lang.security.audit.detect-eval-with-expression
 const fn = new AsyncFunction(
   'agent', 'parallel', 'pipeline', 'phase', 'log', 's3read', 's3write', 's3list', 'args', 'budget', 'workflow',
+  'agentDetailed',
   source,
 )
 
 try {
   const result = await fn(
     hostAgent, hostParallel, hostPipeline, hostPhase, hostLog, hostS3read, hostS3write, hostS3list,
-    args, hostBudget, hostWorkflow,
+    args, hostBudget, hostWorkflow, hostAgentDetailed,
   )
   send({ type: 'done', result: result === undefined ? null : result })
 } catch (e) {


### PR DESCRIPTION
Three related fixes to how failures are bounded and reported.

- `retries={"max_attempts": 1}` does not mean one attempt. In botocore's legacy retry mode it counts retries, resolving to `total_max_attempts: 2`, so one read timeout costs two full timeouts back to back. Switched to `total_max_attempts: 1`, which is what the surrounding comment always claimed.
- A nested `workflow()` run is now capped at the parent's remaining budget minus a reserve, instead of getting a fresh full timeout inside a parent whose kill timer keeps running.
- `agent()` returned `None` for a model flake, a refusal and a read timeout alike, so retry logic had to guess from elapsed time. `_call_agent` now returns `(value, error)`; `agent()` keeps the value-or-null contract and `agentDetailed()` hands back both. Every failure also writes its reason into the run log.
- The JSON parse failure message now separates "no JSON in the output" from "a `{...}` block that `json.loads` rejected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)