### PR TITLE
Keycloak: production mode on RDS PostgreSQL

### DIFF
--- a/docs/enterprise-sso.md
+++ b/docs/enterprise-sso.md
@@ -113,11 +113,11 @@ Design decisions:
 
 | Piece | What it is |
 |---|---|
-| `AgentPlatformTeamAuth` stack | Keycloak (Fargate, dev mode) + `team-a-api`/`team-b-api`/`team-c-api` containers behind one ALB + CloudFront (HTTPS for the OIDC discovery URL); generates the team-c static key (`agent-platform/team-c-api-key`) |
+| `AgentPlatformTeamAuth` stack | Keycloak (Fargate, production mode on RDS PostgreSQL) + `team-a-api`/`team-b-api`/`team-c-api` containers behind one ALB + CloudFront (HTTPS for the OIDC discovery URL); generates the team-c static key (`agent-platform/team-c-api-key`) |
 | `AgentPlatformTeamDemo` stack | The JWT-inbound runtime (`team_demo_kernel`) |
 | `services/keycloak/` | Keycloak image with the realm baked in: groups, users (alice/bob/carol), `portal-web` (public, PKCE) and `gateway-delegate` (confidential, standard token exchange) clients, `team`/audience mappers |
 | `services/team-api/` | One image; `TEAM` selects the team, `TEAM_API_AUTH` the authz depth: `oidc` (JWKS-validating middleware, `tools/call` team-gated, catalog stays listable) or `api-key` (static `X-Api-Key` check only — the no-SSO backend) |
-| `scripts/seed_team_idp.py` | Sets user passwords + pins the delegate client secret (Secrets Manager ⇄ Keycloak) — re-run after any Keycloak restart (dev mode is in-memory) |
+| `scripts/seed_team_idp.py` | Sets user passwords, pins the delegate + robot client secrets (Secrets Manager ⇄ Keycloak) and registers the portal's redirect URI. A one-time bootstrap after the first deploy, and idempotent if run again |
 | `scripts/deploy_team_gateway.py` | Gateway + OAuth2 credential provider (token exchange) + API-key credential provider + the Lambda REQUEST interceptor (inline zip) + three MCP-server targets + the gateway service-role policy; wiring goes to SSM `/agent-platform/team-gateway` |
 | `scripts/e2e_team_auth.py` | The acceptance suite for the auth chain (20 checks, below) |
 | `scripts/seed_team_gateway_registry.py` | Registers the gateway as one **MCP server** in the platform registry (headers carry the `{{user_token}}` placeholder) and publishes the `team-access-tester` agent with it attached |
@@ -137,7 +137,8 @@ cdk deploy AgentPlatformPlatform
 # 2. IdP + team APIs + CloudFront
 cdk deploy AgentPlatformTeamAuth
 
-# 3. seed users + pin the delegate secret (re-run after any Keycloak restart)
+# 3. seed users, pin the client secrets, register the portal redirect URI
+#    (one-time bootstrap; safe to re-run)
 python3 scripts/seed_team_idp.py
 
 # 4. gateway + OBO credential provider + targets (idempotent)
@@ -256,10 +257,22 @@ exercises the whole chain from a pod.
    invocation fails in about a second with
    `Claude Code returned an error result`. `cdk.json` sets
    `anthropic_model` explicitly for all runtimes.
-5. **Keycloak dev mode is in-memory.** Every task restart re-imports the
-   realm from the image and loses passwords — re-run `seed_team_idp.py`.
-   The delegate client secret survives restarts because the seed script
-   pins the Secrets Manager value back into Keycloak.
+5. **Keycloak needs a real database, not dev mode.** It ran `start-dev` on an
+   in-memory H2 database until 2026-08-19, which made every task replacement a
+   silent SSO outage: Fargate retired the task on its own after nine days, the
+   fresh one re-imported the realm from the image, and everything applied
+   *after* that import was gone — the portal's redirect URI, the confidential
+   clients' secrets, the user passwords. Sign-in failed with
+   `invalid_redirect_uri` and the robot client with
+   `invalid_client_credentials` for four hours, until someone noticed and
+   re-ran the seed by hand. It now runs `start --optimized` against RDS
+   PostgreSQL, so that state is durable. Sessions are too: Keycloak 26 keeps
+   `persistent-user-session` enabled by default, storing them in the database
+   rather than only in the local cache, which is what makes the realm's 7-day
+   SSO session mean anything. Note that the realm import runs with the default
+   `IGNORE_EXISTING` strategy, so against a persistent database it applies
+   once — later edits to the realm file do not reach an existing realm, and
+   have to go through the admin API or a partial import.
 6. **Kernel images should pin `claude-agent-sdk`.** A rebuild that silently
    picks up a newer SDK can change CLI bundling behavior; the deployed tags
    (`v14`/`v15`) are pinned builds.
@@ -299,10 +312,12 @@ exercises the whole chain from a pod.
    Keycloak shows a "do you want to log out" confirmation screen instead of
    logging out straight away.
 11. **`seed_team_idp.py` re-applies the stored passwords, it does not rotate
-   them.** Keycloak dev mode loses passwords on restart so they must be set
-   again on every run, but re-applying the value already in Secrets Manager
-   keeps distributed credentials working. Use `--rotate-passwords` to force
-   new ones.
+   them.** Re-applying the value already in Secrets Manager is what makes the
+   script safe to run again: distributed credentials and live browser sessions
+   keep working. Use `--rotate-passwords` to force new ones. Its two URL
+   lookups are deliberately fatal — the portal one used to fail into a warning
+   and skip registering the redirect URI, so a re-seed could report success
+   while leaving browser sign-in rejecting every attempt.
 12. **API-key outbound mirrors the OAuth IAM lesson.** The gateway service
    role needs `bedrock-agentcore:GetResourceApiKey` on the credential
    provider **and** the workload-identity/token-vault resources, plus

--- a/scripts/build-and-push-team-auth.sh
+++ b/scripts/build-and-push-team-auth.sh
@@ -24,4 +24,5 @@ build() {
 build keycloak "$ROOT/services/keycloak"
 build team-api "$ROOT/services/team-api"
 
-echo "Images pushed. Next: cdk deploy AgentPlatformTeamAuth"
+echo "Images pushed. Next: set keycloak_image_tag / team_auth_image_tag in"
+echo "terraform/terraform.tfvars to '${TAG}', then terraform apply."

--- a/scripts/seed_team_idp.py
+++ b/scripts/seed_team_idp.py
@@ -20,20 +20,29 @@ passwords are deliberately NOT in the image or the repo. This script:
   5. sanity-checks a password-grant login for each user and prints the
      ``team`` claim from the issued access token.
 
-Keycloak dev mode uses an in-memory database, so re-run this script after any
-Keycloak task restart.
+Since 2026-08-19 Keycloak runs in production mode on RDS PostgreSQL, so this is
+a one-time bootstrap after the first deploy rather than a repair step after
+every task restart. It stays idempotent: re-running it re-applies the stored
+values instead of generating new ones.
 
 Usage:
     python3 scripts/seed_team_idp.py [--base-url https://dxxxx.cloudfront.net]
 
-Without --base-url the script reads the TeamAuthUrl output of the
-AgentPlatformTeamAuth CloudFormation stack.
+Without --base-url / --portal-url the script reads the `team_auth_url` and
+`portal_url` outputs of the Terraform state in terraform/. It used to read the
+AgentPlatformTeamAuth / AgentPlatformPortal CloudFormation stacks, which were
+deleted in the 2026-08-10 Terraform migration — the portal lookup then failed
+into a warning and skipped registering the redirect URI, which is the step a
+broken login most needs. Both lookups are fatal now; pass
+--skip-portal-redirect to deliberately seed before the portal exists.
 """
 
 import argparse
 import base64
 import json
+import os
 import secrets
+import subprocess  # nosec B404 - fixed argv, no shell
 import sys
 import time
 import urllib.parse
@@ -41,22 +50,37 @@ import urllib.request
 
 import boto3
 
+TERRAFORM_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "terraform")
+
 REALM = "agent-platform"
 CLIENT_ID = "portal-web"
 DELEGATE_CLIENT = "gateway-delegate"
 ROBOT_CLIENT = "robot-order-service"
 ROBOT_TEAM_GROUP = "team-a"
-USERS = ["alice", "bob", "carol", "admin"]
+USERS = ["alice", "bob", "carol", "admin", "jim"]
 ADMIN_USER = "admin"
 ADMIN_GROUP = "platform-admin"
 # desired group membership per user — enforced on every run so a Keycloak
 # instance booted from an older realm image converges to the current model
-# (admin is the only administrator; alice/bob/carol are regular developers)
+# (admin and jim are the administrators; alice/bob/carol are regular developers)
 USER_GROUPS = {
     "alice": ["team-a"],
     "bob": ["team-b"],
     "carol": ["team-c"],
     "admin": [ADMIN_GROUP],
+    "jim": [ADMIN_GROUP],
+}
+# Enough to create an account the realm import did not bring. The import runs
+# with Keycloak's default IGNORE_EXISTING strategy, so against the persistent
+# database a new entry in realm-agent-platform.json never reaches an existing
+# realm — it has to be created through the admin API, here. The realm file
+# still carries these users so a fresh deployment gets them on first boot.
+USER_PROFILES = {
+    "alice": {"firstName": "Alice", "lastName": "TeamA", "email": "alice@example.com"},
+    "bob": {"firstName": "Bob", "lastName": "TeamB", "email": "bob@example.com"},
+    "carol": {"firstName": "Carol", "lastName": "TeamC", "email": "carol@example.com"},
+    "admin": {"firstName": "Platform", "lastName": "Admin", "email": "admin@example.com"},
+    "jim": {"firstName": "Jim", "lastName": "Admin", "email": "jim@example.com"},
 }
 ADMIN_SECRET = "agent-platform/keycloak-admin"  # nosec B105 - secret names
 USERS_SECRET = "agent-platform/team-demo-users"  # nosec B105
@@ -86,6 +110,31 @@ def _api(url: str, token: str, method: str = "GET", payload: dict | None = None)
         return json.loads(raw) if raw else None
 
 
+def _terraform_output(name: str, tf_dir: str) -> str | None:
+    """Read one Terraform output, or None if it cannot be read.
+
+    Callers decide whether a miss is fatal — it is for both of this script's
+    lookups, but the reason differs (no Terraform CLI, no state access, or the
+    stack simply not deployed yet), so the message belongs at the call site.
+    """
+    try:
+        proc = subprocess.run(  # nosec B603 - fixed argv, no shell
+            ["terraform", f"-chdir={tf_dir}", "output", "-raw", name],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"  terraform output {name} failed: {exc}", file=sys.stderr)
+        return None
+    if proc.returncode != 0:
+        print(f"  terraform output {name} failed: {proc.stderr.strip()}", file=sys.stderr)
+        return None
+    value = proc.stdout.strip()
+    return value or None
+
+
 def _claims(jwt_token: str) -> dict:
     payload = jwt_token.split(".")[1]
     payload += "=" * (-len(payload) % 4)
@@ -94,14 +143,27 @@ def _claims(jwt_token: str) -> dict:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--base-url", help="CloudFront base URL of the team-auth stack")
-    parser.add_argument("--stack", default="AgentPlatformTeamAuth")
+    parser.add_argument(
+        "--base-url",
+        help="CloudFront base URL of the team-auth deployment "
+        "(default: the team_auth_url Terraform output)",
+    )
     parser.add_argument(
         "--portal-url",
         help="Portal origin to allow as an OIDC redirect target "
-        "(default: the PortalUrl output of AgentPlatformPortal)",
+        "(default: the portal_url Terraform output)",
     )
-    parser.add_argument("--portal-stack", default="AgentPlatformPortal")
+    parser.add_argument(
+        "--terraform-dir",
+        default=TERRAFORM_DIR,
+        help="directory holding the Terraform state to read URLs from",
+    )
+    parser.add_argument(
+        "--skip-portal-redirect",
+        action="store_true",
+        help="do not register a portal redirect URI (only when the portal is not deployed yet; "
+        "browser sign-in stays broken until it is registered)",
+    )
     parser.add_argument(
         "--rotate-passwords",
         action="store_true",
@@ -109,11 +171,14 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    base_url = args.base_url
+    base_url = args.base_url or _terraform_output("team_auth_url", args.terraform_dir)
     if not base_url:
-        cfn = boto3.client("cloudformation")
-        outputs = cfn.describe_stacks(StackName=args.stack)["Stacks"][0]["Outputs"]
-        base_url = next(o["OutputValue"] for o in outputs if o["OutputKey"] == "TeamAuthUrl")
+        print(
+            "could not determine the team-auth URL: pass --base-url, or run from a "
+            "checkout whose terraform/ has state access",
+            file=sys.stderr,
+        )
+        return 1
     base_url = base_url.rstrip("/")
     issuer = f"{base_url}/realms/{REALM}"
     print(f"IdP: {issuer}")
@@ -146,9 +211,9 @@ def main() -> int:
     print("admin token OK")
 
     # ------------------------- set user passwords ----------------------
-    # Keycloak dev mode loses passwords on restart, so they must be re-applied
-    # every run — but re-applying the *same* value keeps already-distributed
-    # credentials (and anyone's browser session) working.
+    # Passwords now persist in the database, so this is normally a first-run
+    # step. Re-applying the *same* stored value keeps it safe to run again:
+    # already-distributed credentials (and anyone's browser session) survive.
     stored_creds: dict[str, str] = {}
     if not args.rotate_passwords:
         try:
@@ -177,29 +242,37 @@ def main() -> int:
             f"{base_url}/admin/realms/{REALM}/users?username={username}&exact=true",
             admin_token,
         )
-        if not found and username == ADMIN_USER:
-            # instances booted from an older realm image predate this user
+        if not found:
+            # The realm this instance booted from predates the user: either an
+            # older realm image, or — the usual case now — a realm that already
+            # existed, so IGNORE_EXISTING skipped the import entirely.
+            profile = USER_PROFILES.get(username)
+            if not profile:
+                print(
+                    f"user {username} not found in realm {REALM} and no USER_PROFILES "
+                    "entry to create them from",
+                    file=sys.stderr,
+                )
+                return 1
             _api(
                 f"{base_url}/admin/realms/{REALM}/users",
                 admin_token,
                 method="POST",
                 payload={
-                    "username": ADMIN_USER,
+                    "username": username,
                     "enabled": True,
                     "emailVerified": True,
-                    "firstName": "Platform",
-                    "lastName": "Admin",
-                    "email": "admin@example.com",
+                    **profile,
                 },
             )
             found = _api(
                 f"{base_url}/admin/realms/{REALM}/users?username={username}&exact=true",
                 admin_token,
             )
+            if not found:
+                print(f"user {username} could not be created in realm {REALM}", file=sys.stderr)
+                return 1
             print(f"user created: {username}")
-        if not found:
-            print(f"user {username} not found in realm {REALM}", file=sys.stderr)
-            return 1
         user_id = found[0]["id"]
         password = stored_creds.get(username) or secrets.token_urlsafe(18)
         reused = username in stored_creds
@@ -247,7 +320,7 @@ def main() -> int:
     upsert_secret(
         USERS_SECRET,
         json.dumps({"issuer": issuer, "client_id": CLIENT_ID, "users": creds}),
-        "Team-auth demo user credentials (alice/bob/carol + platform admin)",
+        "Team-auth demo user credentials (alice/bob/carol + admin/jim platform admins)",
     )
     print(f"credentials stored in Secrets Manager: {USERS_SECRET}")
 
@@ -257,16 +330,20 @@ def main() -> int:
     # END of a URI, so the realm file cannot ship a host pattern — register
     # the deployed origin here instead (idempotent, re-applied after restarts).
     portal_url = args.portal_url
-    if not portal_url:
-        try:
-            cfn = boto3.client("cloudformation")
-            outputs = cfn.describe_stacks(StackName=args.portal_stack)["Stacks"][0]["Outputs"]
-            portal_url = next(
-                o["OutputValue"] for o in outputs if o["OutputKey"] == "PortalUrl"
+    if not portal_url and not args.skip_portal_redirect:
+        portal_url = _terraform_output("portal_url", args.terraform_dir)
+        # Deliberately fatal. This lookup used to fail into a warning, which is
+        # how a re-seed could report success while leaving browser sign-in
+        # rejecting every request with invalid_redirect_uri.
+        if not portal_url:
+            print(
+                "could not determine the portal URL, so the redirect URI would go "
+                "unregistered and browser sign-in would keep failing with "
+                "invalid_redirect_uri. Pass --portal-url, or --skip-portal-redirect "
+                "if the portal really is not deployed yet.",
+                file=sys.stderr,
             )
-        except Exception as exc:  # noqa: BLE001 - portal not deployed yet
-            print(f"  portal stack not available ({exc}); skipping redirect URI")
-            portal_url = ""
+            return 1
     if portal_url:
         origin = portal_url.rstrip("/")
         portal_clients = _api(
@@ -292,10 +369,10 @@ def main() -> int:
 
     # -------------------- gateway-delegate client secret ----------------
     # AgentCore Identity performs the RFC 8693 token exchange as this
-    # confidential client. Keycloak dev mode regenerates client secrets on
-    # every realm re-import, so we hold the source of truth in Secrets
-    # Manager and write it BACK into Keycloak — the AgentCore credential
-    # provider stays valid across Keycloak restarts.
+    # confidential client. A realm re-import generates a fresh client secret,
+    # so we hold the source of truth in Secrets Manager and write it BACK into
+    # Keycloak — the AgentCore credential provider then stays valid no matter
+    # how the realm got (re)created.
     try:
         stored = json.loads(sm.get_secret_value(SecretId=DELEGATE_SECRET)["SecretString"])
         delegate_secret = stored["client_secret"]
@@ -407,7 +484,7 @@ def main() -> int:
         f"aud={robot_claims.get('aud')}"
     )
 
-    print("\nIdP seeded. Next: cdk deploy AgentPlatformTeamDemo && "
+    print("\nIdP seeded. Next: terraform apply (brings up the team-demo runtime) && "
           "python3 scripts/deploy_team_gateway.py")
     return 0
 

--- a/services/keycloak/Dockerfile
+++ b/services/keycloak/Dockerfile
@@ -1,27 +1,65 @@
-# Keycloak IdP for the team-auth demo (test-grade: dev mode, in-memory H2).
-# The realm (groups team-a/team-b, users alice/bob, portal-web client with a
-# `team` claim mapper) is baked in and imported at boot. User passwords are
-# NOT in the image — scripts/seed_team_idp.py sets them after deploy and
-# stores them in Secrets Manager.
+# Keycloak IdP for the team-auth demo: production mode against RDS PostgreSQL.
 #
-# Runtime env (set by TeamAuthStack): KC_BOOTSTRAP_ADMIN_USERNAME,
-# KC_BOOTSTRAP_ADMIN_PASSWORD, KC_HOSTNAME (https CloudFront URL),
-# KC_HTTP_ENABLED, KC_PROXY_HEADERS, KC_HEALTH_ENABLED.
+# The realm (groups team-a/b/c + platform-admin, the four demo users, the
+# portal-web / gateway-delegate / robot-order-service clients and their `team`
+# claim mappers) is baked in and imported on first boot. Credentials are NOT in
+# the image: scripts/seed_team_idp.py sets user passwords, the confidential
+# clients' secrets and the deployed portal's redirect URI, and stores them in
+# Secrets Manager.
+#
+# Runtime env (set by the team_auth Terraform module):
+#   KC_BOOTSTRAP_ADMIN_USERNAME / KC_BOOTSTRAP_ADMIN_PASSWORD
+#   KC_HOSTNAME (the https CloudFront URL), KC_HTTP_ENABLED, KC_PROXY_HEADERS
+#   KC_DB_URL_HOST / KC_DB_URL_PORT / KC_DB_URL_DATABASE / KC_DB_URL_PROPERTIES
+#   KC_DB_USERNAME / KC_DB_PASSWORD
+#
+# Why production mode and an external database (changed 2026-08-19): dev mode
+# keeps everything in an in-memory H2 database, so a task replacement silently
+# reset the realm to this file. AWS retired the Fargate task on its own after
+# nine days and SSO broke for four hours: the portal's redirect URI and the
+# robot client's secret were gone, and every user session with them. On
+# PostgreSQL that state is durable, and Keycloak 26 leaves
+# `persistent-user-session` enabled by default, so sessions are stored in the
+# database and a restart no longer signs everyone out.
+#
 # Realm-file caveats (Keycloak 26.3.x imports are STRICT — any unknown JSON
 # field aborts the boot, so keep commentary here, not in the realm file):
-# - portal-web redirectUris ship as localhost only; Keycloak matches
-#   wildcards at the END of a URI (https://*.cloudfront.net/* does NOT
-#   work), so scripts/seed_team_idp.py registers the deployed portal's real
-#   origin after deploy.
+# - portal-web redirectUris ship as localhost only; Keycloak matches wildcards
+#   at the END of a URI (https://*.cloudfront.net/* does NOT work), so
+#   scripts/seed_team_idp.py registers the deployed portal's real origin.
 # - the robot-order-service service-account user's group membership is also
 #   applied by the seed script — a realm import cannot express it.
+# - sessions run 7 days (ssoSessionIdleTimeout/ssoSessionMaxLifespan = 604800)
+#   while accessTokenLifespan stays at 1 hour. The portal renews the short
+#   access token from its refresh token, so the long value only sets how long a
+#   signed-in user goes without re-authenticating, not how long a leaked bearer
+#   token stays usable downstream.
+# - the import runs with Keycloak's default IGNORE_EXISTING strategy. Against a
+#   persistent database that means it applies once, on the first boot; later
+#   edits to the realm file do NOT reach an existing realm. Apply those through
+#   the admin API (as the seed script does) or a partial import.
+
+# ---------------------------------- build ----------------------------------
+# Production mode wants an optimized image: the build-time options below are
+# resolved once by `kc.sh build` here instead of on every container start.
+# nosemgrep: dockerfile-source-not-pinned
+FROM quay.io/keycloak/keycloak:26.3 AS builder
+
+ENV KC_DB=postgres
+ENV KC_HEALTH_ENABLED=true
+ENV KC_METRICS_ENABLED=true
+
+RUN /opt/keycloak/bin/kc.sh build
+
+# ----------------------------------- run -----------------------------------
 # nosemgrep: dockerfile-source-not-pinned
 FROM quay.io/keycloak/keycloak:26.3
 # checkov:skip=CKV_DOCKER_2: health is the ALB target-group check on /realms/master.
 # checkov:skip=CKV_DOCKER_3: official Keycloak image already runs as user 1000.
 
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
 COPY realm-agent-platform.json /opt/keycloak/data/import/realm-agent-platform.json
 
-# Dev mode is deliberate: this IdP exists to demonstrate the auth chain in a
-# test environment. Production would use `start` + external DB + replicas.
-CMD ["start-dev", "--import-realm"]
+# --optimized skips the augmentation step at startup: the build above already
+# did it, and re-running it would only slow every boot down.
+CMD ["start", "--optimized", "--import-realm"]

--- a/services/keycloak/realm-agent-platform.json
+++ b/services/keycloak/realm-agent-platform.json
@@ -6,8 +6,8 @@
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,
   "accessTokenLifespan": 3600,
-  "ssoSessionIdleTimeout": 43200,
-  "ssoSessionMaxLifespan": 43200,
+  "ssoSessionIdleTimeout": 604800,
+  "ssoSessionMaxLifespan": 604800,
   "groups": [
     {
       "name": "team-a",
@@ -67,6 +67,17 @@
       "firstName": "Platform",
       "lastName": "Admin",
       "email": "admin@example.com",
+      "groups": [
+        "/platform-admin"
+      ]
+    },
+    {
+      "username": "jim",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jim",
+      "lastName": "Admin",
+      "email": "jim@example.com",
       "groups": [
         "/platform-admin"
       ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,11 +119,12 @@ module "team_auth" {
   source = "./modules/team_auth"
   count  = var.enable_team_auth ? 1 : 0
 
-  vpc_id              = module.network.vpc_id
-  public_subnet_ids   = module.network.public_subnet_ids
-  private_subnet_ids  = module.network.private_subnet_ids
+  vpc_id                 = module.network.vpc_id
+  public_subnet_ids      = module.network.public_subnet_ids
+  private_subnet_ids     = module.network.private_subnet_ids
   team_auth_repos        = module.platform.team_auth_repos
   team_auth_image_tag    = coalesce(var.team_auth_image_tag, var.image_tag)
+  keycloak_image_tag     = coalesce(var.keycloak_image_tag, var.team_auth_image_tag, var.image_tag)
   log_bucket             = module.platform.log_bucket
   cf_log_destination_arn = module.platform.cf_log_destination_arn
   name_suffix            = var.name_suffix

--- a/terraform/modules/team_auth/ecs.tf
+++ b/terraform/modules/team_auth/ecs.tf
@@ -1,4 +1,5 @@
-# Team-auth ECS workloads: Keycloak (dev mode, H2 in-memory) + 3 team APIs.
+# Team-auth ECS workloads: Keycloak (production mode on RDS PostgreSQL, see
+# rds.tf) + 3 team APIs.
 
 resource "aws_ecs_cluster" "team_auth" {
   name = "agent-platform-team-auth${var.name_suffix}"
@@ -54,6 +55,7 @@ data "aws_iam_policy_document" "execution" {
     actions = ["secretsmanager:GetSecretValue"]
     resources = [
       aws_secretsmanager_secret.keycloak_admin.arn,
+      aws_secretsmanager_secret.keycloak_db.arn,
       aws_secretsmanager_secret.team_c_key.arn,
     ]
   }
@@ -88,7 +90,7 @@ resource "aws_ecs_task_definition" "keycloak" {
   container_definitions = jsonencode([
     {
       name      = "keycloak"
-      image     = "${var.team_auth_repos["keycloak"].url}:${var.team_auth_image_tag}"
+      image     = "${var.team_auth_repos["keycloak"].url}:${var.keycloak_image_tag}"
       essential = true
       portMappings = [
         { containerPort = 8080, protocol = "tcp" }
@@ -96,15 +98,33 @@ resource "aws_ecs_task_definition" "keycloak" {
       environment = [
         { name = "KC_BOOTSTRAP_ADMIN_USERNAME", value = "admin" },
         { name = "KC_HOSTNAME", value = local.base_url },
+        # TLS terminates at CloudFront, so the container speaks plain HTTP and
+        # reconstructs the external URL from the forwarded headers. Production
+        # mode disables HTTP by default, hence the explicit opt-in.
         { name = "KC_HTTP_ENABLED", value = "true" },
         { name = "KC_PROXY_HEADERS", value = "xforwarded" },
         { name = "KC_HEALTH_ENABLED", value = "true" },
+        # The vendor is also baked into the image at build time (kc.sh build);
+        # repeating it here keeps `start --optimized` from rejecting a mismatch.
+        { name = "KC_DB", value = "postgres" },
+        { name = "KC_DB_URL_HOST", value = aws_db_instance.keycloak.address },
+        { name = "KC_DB_URL_PORT", value = tostring(aws_db_instance.keycloak.port) },
+        { name = "KC_DB_URL_DATABASE", value = local.db_name },
+        { name = "KC_DB_URL_PROPERTIES", value = local.db_url_properties },
       ]
       secrets = [
         {
           name      = "KC_BOOTSTRAP_ADMIN_PASSWORD"
           valueFrom = "${aws_secretsmanager_secret.keycloak_admin.arn}:password::"
-        }
+        },
+        {
+          name      = "KC_DB_USERNAME"
+          valueFrom = "${aws_secretsmanager_secret.keycloak_db.arn}:username::"
+        },
+        {
+          name      = "KC_DB_PASSWORD"
+          valueFrom = "${aws_secretsmanager_secret.keycloak_db.arn}:password::"
+        },
       ]
       logConfiguration = {
         logDriver = "awslogs"
@@ -127,8 +147,11 @@ resource "aws_ecs_service" "keycloak" {
   health_check_grace_period_seconds = 180
 
   network_configuration {
-    subnets          = var.private_subnet_ids
-    security_groups  = [aws_security_group.service.id]
+    subnets = var.private_subnet_ids
+    security_groups = [
+      aws_security_group.service.id,
+      aws_security_group.keycloak_db_client.id,
+    ]
     assign_public_ip = false
   }
 

--- a/terraform/modules/team_auth/main.tf
+++ b/terraform/modules/team_auth/main.tf
@@ -1,9 +1,10 @@
 # Port of TeamAuthStack: the external IdP (Keycloak) and three team-scoped
 # backend APIs, all behind one ALB + CloudFront.
 #
-# Test-grade by design: Keycloak runs in dev mode with an in-memory H2
-# database (realm structure re-imports from the image at boot; user passwords
-# are re-seeded by scripts/seed_team_idp.py after any task restart).
+# Keycloak runs in production mode against RDS PostgreSQL (rds.tf), so realm
+# state, seeded credentials and user sessions all survive a task replacement.
+# scripts/seed_team_idp.py is a one-time bootstrap now, not a post-restart
+# repair step.
 #
 # The AgentCore Gateway + targets are created by scripts/deploy_team_gateway.py
 # and the JWT-inbound demo runtime lives in the team_demo module — both need

--- a/terraform/modules/team_auth/rds.tf
+++ b/terraform/modules/team_auth/rds.tf
@@ -1,0 +1,142 @@
+# Keycloak's database.
+#
+# Keycloak ran in dev mode on an in-memory H2 database until 2026-08-19. That
+# made every task replacement a silent SSO outage: Fargate retired the task on
+# its own after nine days, the fresh one re-imported the realm from the image,
+# and everything applied *after* the import was gone — the portal's redirect
+# URI, the confidential clients' secrets, the user passwords, all of it. Login
+# failed with `invalid_redirect_uri` and the robot client with
+# `invalid_client_credentials` until scripts/seed_team_idp.py was re-run by hand.
+#
+# With an external database that state is durable, and so are user sessions:
+# Keycloak 26 keeps `persistent-user-session` on by default, so sessions live in
+# the database rather than only in the local Infinispan cache. A task
+# replacement no longer signs everyone out, which is what makes the realm's
+# 7-day SSO session mean anything.
+
+resource "aws_db_subnet_group" "keycloak" {
+  name       = "agent-platform-keycloak${var.name_suffix}"
+  subnet_ids = var.private_subnet_ids
+}
+
+# A client SG of its own rather than reusing aws_security_group.service: that
+# one is shared with the three team APIs, and they have no business reaching
+# the database. The Keycloak service carries both SGs.
+resource "aws_security_group" "keycloak_db_client" {
+  name        = "agent-platform-keycloak-db-client${var.name_suffix}"
+  description = "Marks the Keycloak task as a client of its database"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "keycloak_db" {
+  name        = "agent-platform-keycloak-db${var.name_suffix}"
+  description = "Keycloak database - reachable only from the Keycloak task"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "PostgreSQL from the Keycloak task"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.keycloak_db_client.id]
+  }
+}
+
+# Alphanumeric: the value travels through a container environment variable into
+# a JDBC URL, and RDS rejects '/', '@', '"' and '\'' in a master password
+# anyway. 40 characters of base62 is ~238 bits, so dropping punctuation costs
+# nothing that matters.
+resource "random_password" "keycloak_db" {
+  length  = 40
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "keycloak_db" {
+  name        = "agent-platform/keycloak-db${var.name_suffix}"
+  description = "Keycloak PostgreSQL credentials (team-auth demo IdP)"
+}
+
+resource "aws_secretsmanager_secret_version" "keycloak_db" {
+  secret_id = aws_secretsmanager_secret.keycloak_db.id
+  secret_string = jsonencode({
+    username = local.db_username
+    password = random_password.keycloak_db.result
+    dbname   = local.db_name
+    host     = aws_db_instance.keycloak.address
+    port     = aws_db_instance.keycloak.port
+  })
+}
+
+# RDS would create this itself on first log export, but without a retention
+# policy — i.e. it would keep Postgres logs forever. Creating it here pins the
+# same 7 days the ECS log groups use.
+resource "aws_cloudwatch_log_group" "keycloak_db" {
+  name              = "/aws/rds/instance/agent-platform-keycloak${var.name_suffix}/postgresql"
+  retention_in_days = 7
+}
+
+resource "aws_db_instance" "keycloak" {
+  identifier     = "agent-platform-keycloak${var.name_suffix}"
+  engine         = "postgres"
+  instance_class = "db.t4g.micro"
+
+  # Major version only, so AWS picks the current default minor and
+  # auto_minor_version_upgrade can move it during the maintenance window
+  # without Terraform reporting a drift every time.
+  engine_version             = "17"
+  auto_minor_version_upgrade = true
+
+  db_name  = local.db_name
+  username = local.db_username
+  password = random_password.keycloak_db.result
+
+  db_subnet_group_name   = aws_db_subnet_group.keycloak.name
+  vpc_security_group_ids = [aws_security_group.keycloak_db.id]
+  publicly_accessible    = false
+
+  # Single-AZ is deliberate for a demo IdP: it halves the bill, and the failure
+  # it exposes (a few minutes of downtime during a maintenance window) is both
+  # rarer and milder than the one being fixed here, since sessions now survive
+  # a restart. Set multi_az = true if the demo needs to ride out an AZ event.
+  multi_az = false
+
+  storage_type      = "gp3"
+  allocated_storage = 20
+  # Autoscale rather than let a full disk take the IdP down; nothing in this
+  # workload should ever approach it.
+  max_allocated_storage = 100
+  storage_encrypted     = true
+
+  backup_retention_period = 7
+  backup_window           = "17:00-18:00" # 02:00-03:00 JST
+  maintenance_window      = "Mon:18:00-Mon:19:00"
+  copy_tags_to_snapshot   = true
+
+  # The realm structure re-imports from the image, but the seeded credentials
+  # and client secrets do not: losing this volume means another manual re-seed.
+  deletion_protection       = true
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "agent-platform-keycloak-final${var.name_suffix}"
+
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+
+  depends_on = [aws_cloudwatch_log_group.keycloak_db]
+}
+
+locals {
+  db_name     = "keycloak"
+  db_username = "keycloak"
+
+  # rds.force_ssl is 1 in the default postgres17 parameter group, so an
+  # unencrypted connection is refused outright. `require` encrypts without
+  # pinning the CA; verify-full would additionally need the RDS CA bundle in
+  # the image truststore and a plan for rotating it.
+  db_url_properties = "?sslmode=require"
+}

--- a/terraform/modules/team_auth/variables.tf
+++ b/terraform/modules/team_auth/variables.tf
@@ -32,6 +32,11 @@ variable "team_auth_image_tag" {
   type = string
 }
 
+# Resolved by the root module, which falls back to team_auth_image_tag.
+variable "keycloak_image_tag" {
+  type = string
+}
+
 variable "name_suffix" {
   type    = string
   default = ""

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -38,6 +38,7 @@ image_tag = "latest"
 # mcp_tools_image_tag   = ""
 # backend_image_tag     = ""
 # team_auth_image_tag   = ""
+# keycloak_image_tag    = ""   # defaults to team_auth_image_tag; set to move Keycloak alone
 # team_demo_image_tag   = ""
 
 # --- portal auth ------------------------------------------------------------

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -122,6 +122,15 @@ variable "team_auth_image_tag" {
   default = ""
 }
 
+# Keycloak and the team APIs are built from separate Dockerfiles but shared one
+# tag until 2026-08-19, so rebuilding only Keycloak left the three team-API
+# services pulling a tag that was never pushed — they then failed to start in a
+# loop. Override this to move Keycloak on its own.
+variable "keycloak_image_tag" {
+  type    = string
+  default = ""
+}
+
 variable "team_demo_image_tag" {
   type    = string
   default = ""


### PR DESCRIPTION
Keycloak ran in dev mode on the in-memory H2 database, so the realm was whatever the image baked in and everything seeded afterwards — the portal redirect URI, both confidential clients' secrets, the user passwords — vanished when the task was replaced. The symptom is a login failing `invalid_redirect_uri` beside a robot failing `invalid_client_credentials`.

Now production mode against RDS PostgreSQL, credentials generated into Secrets Manager, deletion protection and seven-day backups. `seed_team_idp.py` becomes a one-time bootstrap rather than something to re-run after every restart, and stays idempotent.

Realm import remains `IGNORE_EXISTING`: once the database holds the realm, editing the baked JSON and redeploying changes nothing, so realm edits go through the admin API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)