### PR TITLE
gitignore: keep your own deployment's operational state out of the sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ cdk.context.json
 
 # TypeScript incremental build info
 *.tsbuildinfo
+
+# Your own deployment's operational state — agent instructions pinned to your
+# environment, editor settings, archived stack templates. Keep it in a repo of
+# your own rather than in the sample.
+CLAUDE.md
+.kiro/
+.cfn-archive/


### PR DESCRIPTION
Agent instructions pinned to one environment, editor settings and archived stack templates belong in a repo of your own rather than in the sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)