### PR TITLE
fix: resolve CodeQL high findings and Dependabot postcss alert

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
         "autoprefixer": "^10.4.20",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.26",
         "tailwindcss": "^3.4.15",
         "typescript": "^5.6.3",
         "vite": "^6.4.3"
@@ -2032,9 +2032,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2138,9 +2138,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2158,7 +2158,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.26",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.6.3",
     "vite": "^6.4.3"

--- a/runtimes/agent-sdk-kernel/src/llm_shim.py
+++ b/runtimes/agent-sdk-kernel/src/llm_shim.py
@@ -153,7 +153,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             self.send_response(resp.status)
             for k, v in resp.getheaders():
                 if k.lower() not in _DROP_RESPONSE_HEADERS:
-                    self.send_header(k, v)
+                    # http.server does not validate outgoing headers, so strip
+                    # CR/LF before echoing the edge's headers back — a
+                    # misbehaving upstream must not be able to smuggle extra
+                    # header lines into our response.
+                    self.send_header(
+                        k.replace("\r", "").replace("\n", ""),
+                        v.replace("\r", "").replace("\n", ""),
+                    )
             self.send_header("Transfer-Encoding", "chunked")
             self.end_headers()
             # read1 returns what has arrived rather than waiting for a full

--- a/runtimes/agent-sdk-kernel/src/mcp_hub_proxy.py
+++ b/runtimes/agent-sdk-kernel/src/mcp_hub_proxy.py
@@ -197,7 +197,9 @@ def main() -> int:
     if missing:
         log(f"missing configuration: {', '.join(missing)} — refusing to start")
         return 2
-    log(f"forwarding to {url} as actor {access_key}")
+    # No credential-derived value in logs — the hub names the verified actor
+    # in its own log line, which is where per-application audit belongs.
+    log(f"forwarding to {url}")
     HubProxy(url, access_key, secret_key, sso_token, sso_token_file).run()
     return 0
 

--- a/runtimes/claude-code-kernel/scripts/mcp_hub_proxy.py
+++ b/runtimes/claude-code-kernel/scripts/mcp_hub_proxy.py
@@ -197,7 +197,9 @@ def main() -> int:
     if missing:
         log(f"missing configuration: {', '.join(missing)} — refusing to start")
         return 2
-    log(f"forwarding to {url} as actor {access_key}")
+    # No credential-derived value in logs — the hub names the verified actor
+    # in its own log line, which is where per-application audit belongs.
+    log(f"forwarding to {url}")
     HubProxy(url, access_key, secret_key, sso_token, sso_token_file).run()
     return 0
 

--- a/scripts/seed_mcp_hub_demo.py
+++ b/scripts/seed_mcp_hub_demo.py
@@ -335,8 +335,8 @@ def main() -> int:
         attrs = {**(user_rep.get("attributes") or {}), "department": [dept]}
         _api(f"{base_url}/admin/realms/{REALM}/users/{user_rep['id']}",
              admin_token, method="PUT", payload={**user_rep, "attributes": attrs})
-    print(f"portal client mapped for hub access: {portal_client_id} "
-          f"(aud+department; alice=hr, others=sales)")
+    # the client id comes out of the users secret, so it stays out of stdout
+    print("portal client mapped for hub access (aud+department; alice=hr, others=sales)")
 
     # ------------------------ platform objects --------------------------
     portal_token = _post_form(
@@ -412,9 +412,9 @@ def main() -> int:
             SecretString=json.dumps({"access_key": "dev-workbench",
                                      "secret_key": secrets.token_urlsafe(32)}),
         )
-        print(f"workbench actor minted: dev-workbench ({workbench_secret})")
+        print("workbench actor minted: dev-workbench")
     except sm.exceptions.ResourceExistsException:
-        print(f"workbench actor exists: dev-workbench ({workbench_secret})")
+        print("workbench actor exists: dev-workbench")
 
     ssm = boto3.client("ssm")
     command_id = ssm.send_command(


### PR DESCRIPTION
The first CodeQL scan after #28 merged opened 5 high + 2 medium code-scanning alerts, plus 1 medium Dependabot alert. This fixes all of them in code (no dismissals).

## CodeQL `py/clear-text-logging-sensitive-data` — 5 high (#15–#19)

- **`mcp_hub_proxy.py` (both copies)**: the startup log printed the actor access key, which is parsed out of the Secrets Manager payload — so CodeQL correctly tainted it. The access key is a public identifier by protocol, but there is no reason to log anything credential-derived: the hub logs the verified actor on its side, which is where per-application audit belongs. The log now names only the target URL. Both copies remain byte-identical (diff-verified).
- **`seed_mcp_hub_demo.py`**: three prints included values read from the users secret (the portal client id) or Secrets Manager secret *names*. None is a secret value, but keeping them out of stdout costs nothing — the secret names still reach the hub host through the SSM refresh command, which is not a logging sink.

## CodeQL `py/http-response-splitting` — 2 medium (#13–#14)

`llm_shim.py` echoed upstream response headers verbatim via `send_header`, which `http.server` does not validate. CR/LF are now stripped from header names and values, so a misbehaving edge cannot smuggle extra header lines into the shim's response. Genuine hardening, not just taint-appeasement.

## Dependabot — postcss (medium)

`postcss` 8.5.19 → 8.5.26 (GHSA-fxqj-rqcc-2cmp requires ≥ 8.5.23).

## Verification

- `scripts/test_mcp_hub_proxy.py`: 7/7 pass (round-trip signing, token file, hot rotation)
- both proxy copies byte-identical
- `npm run build` in `frontend/` clean on postcss 8.5.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)