### PR TITLE
Isolate schedules per creator; add a super-administrator tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ architecture, all live:
 - **Scheduler** — cron / `rate(N minutes)` schedules against any kernel or
   published agent, fired by **EventBridge Scheduler → Lambda** (retries +
   DLQ), with an in-process tick loop as the local-development fallback.
+  Schedules are isolated per creator: administrators see and manage only the
+  schedules they created themselves, so one operator cannot silently pause
+  another's production job. A super-administrator tier
+  (`PLATFORM_SUPER_ADMIN_GROUP` / `PLATFORM_SUPER_ADMIN_USERS`) sees and
+  manages every schedule.
 - **Channels** — entry points for external systems. Simple token webhooks,
   plus an **IAM service entry**: a *private* API Gateway (SigV4-authenticated,
   reachable only through allow-listed VPC interface endpoints) with an async

--- a/backend/app/api/schedules.py
+++ b/backend/app/api/schedules.py
@@ -1,4 +1,15 @@
-"""Scheduler endpoints."""
+"""Scheduler endpoints.
+
+Schedules are isolated per creator. The router stays admin-only (a schedule
+fires as the platform, so publishing one is a privileged act), but one
+administrator's schedule is not another administrator's to touch: listing
+returns only what the caller created, and every mutation checks
+``created_by`` against the caller. The plain admin flag does not override
+this — a shared admin role is exactly the situation where a colleague
+flipping someone else's production schedule off goes unnoticed until the
+output stops arriving. Super-administrators (``Principal.is_super_admin``)
+are the one exception: they see and manage every schedule.
+"""
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -10,9 +21,36 @@ from app.services.schedule_service import schedule_service
 router = APIRouter(prefix="/api/v1/schedules", tags=["schedules"], dependencies=[Depends(require_admin)])
 
 
+def _super(user: str) -> bool:
+    return bool(getattr(user, "is_super_admin", False))
+
+
+def _owned(schedule_id: str, user: str) -> dict:
+    """Load a schedule the caller may manage; 404 if missing, 403 if someone else's.
+
+    Super-administrators pass regardless of ``created_by``.
+
+    The two stay distinct on purpose: a 403 is an attempted cross-owner
+    change, which is the signal an operator needs when a schedule stops
+    firing and nobody admits to touching it.
+    """
+    item = schedule_service.get_raw(schedule_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    if not _super(user) and item.get("created_by", "") != str(user):
+        raise HTTPException(
+            status_code=403,
+            detail="Only the user who created this schedule, or a super-administrator, can change it",
+        )
+    return item
+
+
 @router.get("")
 def list_schedules(user: str = Depends(get_current_user)):
-    return schedule_service.list_schedules()
+    schedules = schedule_service.list_schedules()
+    if _super(user):
+        return schedules
+    return [s for s in schedules if s.get("created_by", "") == str(user)]
 
 
 @router.post("")
@@ -34,18 +72,16 @@ def create_schedule(req: ScheduleCreateRequest, user: str = Depends(get_current_
 
 @router.post("/{schedule_id}/enable")
 def enable_schedule(schedule_id: str, user: str = Depends(get_current_user)):
+    _owned(schedule_id, user)
     schedule = schedule_service.set_enabled(schedule_id, True)
-    if not schedule:
-        raise HTTPException(status_code=404, detail="Schedule not found")
     audit_service.record(user, "schedule.enable", f"schedule:{schedule['name']}")
     return schedule
 
 
 @router.post("/{schedule_id}/disable")
 def disable_schedule(schedule_id: str, user: str = Depends(get_current_user)):
+    _owned(schedule_id, user)
     schedule = schedule_service.set_enabled(schedule_id, False)
-    if not schedule:
-        raise HTTPException(status_code=404, detail="Schedule not found")
     audit_service.record(user, "schedule.disable", f"schedule:{schedule['name']}")
     return schedule
 
@@ -53,9 +89,7 @@ def disable_schedule(schedule_id: str, user: str = Depends(get_current_user)):
 @router.post("/{schedule_id}/run-now")
 def run_now(schedule_id: str, user: str = Depends(get_current_user)):
     """Fire one occurrence immediately (does not shift the recurring clock)."""
-    item = schedule_service.get_raw(schedule_id)
-    if not item:
-        raise HTTPException(status_code=404, detail="Schedule not found")
+    item = _owned(schedule_id, user)
     result = schedule_service.run_once(item)
     audit_service.record(user, "schedule.run_now", f"schedule:{item.get('name', schedule_id)}")
     return result
@@ -63,7 +97,7 @@ def run_now(schedule_id: str, user: str = Depends(get_current_user)):
 
 @router.delete("/{schedule_id}")
 def delete_schedule(schedule_id: str, user: str = Depends(get_current_user)):
-    if not schedule_service.delete_schedule(schedule_id):
-        raise HTTPException(status_code=404, detail="Schedule not found")
-    audit_service.record(user, "schedule.delete", f"schedule:{schedule_id}")
+    item = _owned(schedule_id, user)
+    schedule_service.delete_schedule(schedule_id)
+    audit_service.record(user, "schedule.delete", f"schedule:{item.get('name', schedule_id)}")
     return {"ok": True}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -68,6 +68,13 @@ class Settings(BaseSettings):
     # schedule-runner Lambda signs in as (agent-platform/portal-admin secret).
     admin_group: str = "platform-admin"
     admin_users: str = "admin"
+    # A second tier above administrators. Administrators share the management
+    # surface but own their schedules individually (one admin cannot pause
+    # another's job); super-administrators see and manage every schedule.
+    # Same two mechanisms as the admin tier: an IdP group, or a comma-separated
+    # username list. Super-administrators are administrators implicitly.
+    super_admin_group: str = "platform-super-admin"
+    super_admin_users: str = "admin"
 
     # IAM service entry (needs the PortalStack's API Gateway front door):
     # the gateway injects a shared secret header so the backend can tell

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -24,6 +24,7 @@ class Principal(str):
     """
 
     is_admin: bool = False
+    is_super_admin: bool = False
     groups: tuple[str, ...] = ()
 
 
@@ -52,7 +53,16 @@ def _principal(
         # schedule-runner Lambda's portal-admin delegation user).
         admin_users = {u.strip() for u in settings.admin_users.split(",") if u.strip()}
         admin = settings.admin_group in principal.groups or username in admin_users
-    principal.is_admin = admin
+    super_users = {u.strip() for u in settings.super_admin_users.split(",") if u.strip()}
+    super_admin = (
+        settings.super_admin_group in principal.groups
+        or username in super_users
+        # An explicit admin=True with no IdP claims is a development mode:
+        # the pre-RBAC "one operator owns everything" world, so super too.
+        or (claims is None and admin is True)
+    )
+    principal.is_super_admin = bool(super_admin)
+    principal.is_admin = bool(admin or super_admin)
     return principal
 
 
@@ -69,7 +79,10 @@ def get_current_user(authorization: str = Header(default="")) -> Principal:
       4. Open — local development only.
 
     Admin role: membership of ``settings.admin_group`` in the token's group
-    claims, or the username appearing in ``settings.admin_users``. Modes 3/4
+    claims, or the username appearing in ``settings.admin_users``. Super-admin
+    (``is_super_admin``): the same test against ``super_admin_group`` /
+    ``super_admin_users`` — the tier that may manage other users' schedules.
+    Modes 3/4
     have no IdP and are development modes — the caller is treated as admin so
     a local backend behaves like the pre-RBAC platform.
     """

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -129,6 +129,7 @@ if not settings.entry_only:
         return {
             "user": user,
             "is_admin": getattr(user, "is_admin", False),
+            "is_super_admin": getattr(user, "is_super_admin", False),
             "groups": list(getattr(user, "groups", ())),
             "teams": [team] if isinstance(team, str) else [str(t).strip("/") for t in team],
             "issuer": claims.get("iss", ""),

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -114,7 +114,7 @@ export default function AppShell() {
                     {user}
                   </p>
                   <p className="text-[11px] leading-tight text-slate-400">
-                    {identity?.is_admin ? 'Administrator' : identity ? 'Developer' : ''}
+                    {identity?.is_super_admin ? 'Super administrator' : identity?.is_admin ? 'Administrator' : identity ? 'Developer' : ''}
                     {identity?.issuer ? ' · SSO' : identity ? ' · signed in' : 'signed in'}
                   </p>
                 </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -47,6 +47,7 @@ export interface Kernel {
 export interface Identity {
   user: string
   is_admin: boolean
+  is_super_admin?: boolean
   groups: string[]
   teams: string[]
   issuer: string


### PR DESCRIPTION
## What

- **Schedules are owned by their creator.** `GET /api/v1/schedules` returns only the caller's schedules; `enable` / `disable` / `run-now` / `delete` check `created_by` and answer **403** for another user's schedule (404 stays distinct for a missing one). The plain admin flag no longer overrides this.
- **New super-administrator tier** that sees and manages every schedule. Derived like the admin tier: IdP group `PLATFORM_SUPER_ADMIN_GROUP` (default `platform-super-admin`) or username in `PLATFORM_SUPER_ADMIN_USERS` (default `admin`). Super-administrators are administrators implicitly; no-IdP development modes stay fully privileged as before.
- `/api/v1/me` exposes `is_super_admin`; the shell labels the role.

## Why

The scheduler router was admin-only but flat. With a shared admin role, one operator could pause another's production schedule and the only trace was an audit line. Ownership makes that a 403; the super tier keeps a way to manage everything for the platform owner.

## Testing

- In-process FastAPI tests (15 cases): role derivation for group / user-list / dev-mode principals; owner vs non-owner vs super-admin across list, enable, disable, run-now, delete; 404 for unknown ids.
- Deployed as backend `v33` and verified against the live portal with two administrator accounts: the non-owner gets an empty list and 403 on every mutation; the super-administrator sees and re-enables the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
